### PR TITLE
Manage GitHub org access from the UI and fix blocked dashboard form posts

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -25,6 +25,10 @@ export default defineConfig({
     // like the dashboard account-deletion action). Same-origin JSON fetches
     // to /api/* are unaffected.
     checkOrigin: true,
+    allowedDomains: [
+      { hostname: 'gitset.dev', protocol: 'https' },
+      { hostname: 'localhost' },
+    ],
   },
 
   vite: {

--- a/src/components/RepositorySelector.tsx
+++ b/src/components/RepositorySelector.tsx
@@ -352,6 +352,17 @@ export function RepositorySelector({
                                     >
                                         <span className="ml-6">+ Enter manually</span>
                                     </div>
+                                    <div className="border-t my-1"></div>
+                                    <a
+                                        href="/api/auth/github/manage"
+                                        target="_blank"
+                                        rel="noopener noreferrer"
+                                        className="relative flex cursor-pointer select-none items-center rounded-sm px-2 py-1.5 text-xs outline-none text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+                                    >
+                                        <span className="ml-6">
+                                            Can't find your organization or repository? Manage GitHub permissions, then refresh.
+                                        </span>
+                                    </a>
                                 </div>
                             </div>
                         </>

--- a/src/pages/api/auth/github/manage.ts
+++ b/src/pages/api/auth/github/manage.ts
@@ -1,0 +1,12 @@
+import type { APIContext } from "astro";
+import { requireEnv } from "@/lib/env";
+
+export async function GET(_context: APIContext) {
+    const clientId = requireEnv("GITHUB_AUTH_CLIENT");
+    return new Response(null, {
+        status: 302,
+        headers: {
+            Location: `https://github.com/settings/connections/applications/${clientId}`,
+        },
+    });
+}

--- a/src/pages/dashboard.astro
+++ b/src/pages/dashboard.astro
@@ -232,6 +232,35 @@ const joinedDate = new Date(
                         </div>
                     </div>
 
+                    <div class="rounded-lg border border-border bg-card p-5">
+                        <h3 class="font-semibold flex items-center gap-2">
+                            GitHub connection
+                        </h3>
+                        <p class="text-sm text-muted-foreground mt-1">
+                            Connected as <span class="font-medium text-foreground">{user.user.username || user.user.gitsetKey}</span>.
+                            If you recently joined a GitHub organization, or an
+                            organization or repository is missing from the
+                            repository selector, grant Gitset access to it and
+                            sync your permissions.
+                        </p>
+                        <div class="mt-3 flex flex-col sm:flex-row gap-2">
+                            <a
+                                href="/api/auth/github/manage"
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                class="inline-flex items-center justify-center gap-2 rounded-md text-sm font-medium transition-colors bg-primary text-primary-foreground hover:bg-primary/90 h-9 px-4"
+                            >
+                                Manage organization access
+                            </a>
+                            <a
+                                href="/api/auth/github?next=/dashboard"
+                                class="inline-flex items-center justify-center gap-2 rounded-md text-sm font-medium transition-colors border border-input bg-background hover:bg-accent hover:text-accent-foreground h-9 px-4"
+                            >
+                                Re-authorize &amp; Sync
+                            </a>
+                        </div>
+                    </div>
+
                     <SessionList
                         client:load
                         sessions={userSessions}


### PR DESCRIPTION
## Summary
- New `GET /api/auth/github/manage` — redirects to GitHub's own grant page for the Gitset OAuth app, the one place where organization access is actually approved for OAuth apps.
- Repository selector: persistent footer row — *"Can't find your organization or repository? Manage GitHub permissions, then refresh."* — opening that page in a new tab; the existing refresh button then picks up newly granted repos.
- Dashboard: new **GitHub connection** card showing the connected account with two actions: **Manage organization access** (grant page) and **Re-authorize & Sync** (re-runs the normal OAuth flow, whose callback already upserts the stored token for existing users — no session/backend changes needed).

## Also fixes: production dashboard forms were dead
Every dashboard form POST in production failed with **"Cross-site POST form submissions are forbidden"** (revoke one session, revoke all others, delete account). Root cause: Astro ignores `X-Forwarded-Proto` unless `security.allowedDomains` is configured, so behind Cloud Run's TLS-terminating proxy every request reconstructed as `http://gitset.dev` while browsers sent `Origin: https://gitset.dev` — `checkOrigin` then rejected legitimate same-origin submissions. Declaring the allowlist restores trust in the forwarded protocol.

Reproduced pre-fix: a same-origin form POST probe against production returns **403** today.

## What this deliberately does NOT touch
- The OAuth handshake itself (initiation, callback, token exchange) is unchanged — only additive endpoints/links around it.
- Backup Automator and every other tool flow: untouched.

Closes #25 (web portion — CLI counterpart lands in `gitset-cli-v2`; the backend needs no changes since the entire OAuth flow lives in this app and the callback already handles token refresh).

## Test plan
- [x] `astro check` — 0 errors.
- [x] Local: `/api/auth/github/manage` 302s to `github.com/settings/connections/applications/<client_id>` with the environment's client id; homepage renders.
- [x] Production pre-fix probe: same-origin form POST → 403 (bug reproduced).
- [ ] Post-deploy: same probe must no longer 403; dashboard "Revoke all other sessions" works; OAuth login unchanged.