### PR TITLE
fix: preserve UTF-8 when reading manifest content for version sync

### DIFF
--- a/src/components/tools/ReleaseCreator.tsx
+++ b/src/components/tools/ReleaseCreator.tsx
@@ -47,13 +47,17 @@ const MANIFEST_CANDIDATES = [
     { type: 'python', file: 'pyproject.toml' },
 ];
 
+function decodeBase64Utf8(base64: string): string {
+    return decodeURIComponent(escape(atob(base64.replace(/\n/g, ''))));
+}
+
 async function findManifestFile(owner: string, name: string, branch: string) {
     for (const candidate of MANIFEST_CANDIDATES) {
         const res = await ghFetch(`/repos/${owner}/${name}/contents/${candidate.file}?ref=${branch}`);
         if (res.ok) {
             const data = await res.json();
             if (data && typeof data.content === 'string') {
-                return { type: candidate.type, file: candidate.file, sha: data.sha, content: atob(data.content.replace(/\n/g, '')) };
+                return { type: candidate.type, file: candidate.file, sha: data.sha, content: decodeBase64Utf8(data.content) };
             }
         }
     }
@@ -68,7 +72,7 @@ async function findManifestFile(owner: string, name: string, branch: string) {
                     if (res.ok) {
                         const data = await res.json();
                         if (data && typeof data.content === 'string') {
-                            return { type: 'gemspec', file: gem.name, sha: data.sha, content: atob(data.content.replace(/\n/g, '')) };
+                            return { type: 'gemspec', file: gem.name, sha: data.sha, content: decodeBase64Utf8(data.content) };
                         }
                     }
                 }


### PR DESCRIPTION
## Summary
- `findManifestFile()` in `ReleaseCreator.tsx` decoded GitHub's base64 file content with a plain `atob()`. `atob` returns a "binary string" where each character is one raw byte, not a decoded Unicode code point — so any multi-byte UTF-8 sequence (accented author names, non-ASCII text anywhere in the manifest) got corrupted into mojibake as soon as the file was parsed and later re-serialized (e.g. `"Iván"` → `"IvÃ¡n"`).
- The encode side of this same file already uses the correct UTF-8-safe pairing (`btoa(unescape(encodeURIComponent(...)))`) for writing content back to GitHub — this fix makes the decode side use its exact inverse (`decodeURIComponent(escape(atob(...)))`), so read and write are symmetric.
- Root cause was in the base64 decode step, not in `JSON.stringify` escaping as the issue's own diagnosis suggested — `JSON.stringify` does not escape non-ASCII characters by default, confirmed with a local round-trip test before writing the fix.

Closes gitset-dev/gitset#32

## Test plan
- [x] Node-level round-trip test: encoded a JSON manifest containing `"Iván <ivan@example.com>"` the same way GitHub does, confirmed the old `atob`-only decode corrupts it and the new decode round-trips byte-for-byte.
- [x] `astro check`: 0 errors.
- [x] Manual browser verification via a mocked-fetch harness: manifest containing the accented author name flows through detect → diff modal → "Update & Create Release" → inspected the actual PUT payload sent to GitHub and confirmed `"Iván"` survives intact alongside the bumped version.