### PR TITLE
Align dark-theme surfaces with the hero video and standardize card radius to rounded-3xl

### DIFF
--- a/src/components/ConfirmationModal.tsx
+++ b/src/components/ConfirmationModal.tsx
@@ -47,7 +47,7 @@ export default function ConfirmationModal({
                 className="absolute inset-0 bg-background/80 backdrop-blur-sm transition-opacity"
                 onClick={onClose}
             />
-            <div className="relative w-full max-w-md transform overflow-hidden rounded-xl bg-card border border-border p-6 shadow-2xl transition-all animate-in fade-in zoom-in-95 duration-200">
+            <div className="relative w-full max-w-md transform overflow-hidden rounded-3xl bg-card border border-border p-6 shadow-2xl transition-all animate-in fade-in zoom-in-95 duration-200">
                 <div className="absolute right-4 top-4">
                     <button
                         onClick={onClose}

--- a/src/components/DashboardActions.tsx
+++ b/src/components/DashboardActions.tsx
@@ -23,7 +23,7 @@ export default function DashboardActions() {
 
     return (
         <>
-            <div className="rounded-xl border border-destructive/20 bg-destructive/5 text-card-foreground shadow-sm p-6">
+            <div className="rounded-3xl border border-destructive/20 bg-destructive/5 text-card-foreground shadow-sm p-6">
                 <h3 className="font-semibold text-destructive flex items-center gap-2 mb-2">
                     <Shield className="h-4 w-4" /> Danger Zone
                 </h3>

--- a/src/components/LoginModal.tsx
+++ b/src/components/LoginModal.tsx
@@ -35,7 +35,7 @@ export default function LoginModal({ isOpen, onClose, next }: LoginModalProps) {
                 className="absolute inset-0 bg-background/80 backdrop-blur-sm transition-opacity"
                 onClick={onClose}
             />
-            <div className="relative w-full max-w-md transform overflow-hidden rounded-xl bg-card border border-border p-6 shadow-2xl transition-all animate-in fade-in zoom-in-95 duration-200">
+            <div className="relative w-full max-w-md transform overflow-hidden rounded-3xl bg-card border border-border p-6 shadow-2xl transition-all animate-in fade-in zoom-in-95 duration-200">
                 <div className="absolute right-4 top-4">
                     <button
                         onClick={onClose}

--- a/src/components/ProviderKeysManager.tsx
+++ b/src/components/ProviderKeysManager.tsx
@@ -154,7 +154,7 @@ export default function ProviderKeysManager({ triggerLabel = 'Manage AI provider
             role="dialog"
             aria-modal="true"
             aria-labelledby="byoai-modal-title"
-            className="w-full max-w-2xl max-h-[90vh] overflow-y-auto rounded-xl border border-zinc-800 bg-zinc-900 text-zinc-100 shadow-2xl"
+            className="w-full max-w-2xl max-h-[90vh] overflow-y-auto rounded-3xl border border-zinc-800 bg-zinc-900 text-zinc-100 shadow-2xl"
             onClick={(e) => e.stopPropagation()}
           >
             <div className="flex items-center justify-between border-b border-zinc-800 px-5 py-4">

--- a/src/components/SessionList.tsx
+++ b/src/components/SessionList.tsx
@@ -39,7 +39,7 @@ export default function SessionList({ sessions, currentSessionId }: SessionListP
     };
 
     return (
-        <div className="rounded-xl border border-border bg-card text-card-foreground shadow-sm">
+        <div className="rounded-3xl border border-border bg-card text-card-foreground shadow-sm">
             <div className="flex flex-col space-y-1.5 p-6">
                 <h3 className="font-semibold leading-none tracking-tight flex items-center gap-2 text-xl">
                     <Monitor className="h-5 w-5 text-brand" />

--- a/src/components/TemplateEditorModal.tsx
+++ b/src/components/TemplateEditorModal.tsx
@@ -182,7 +182,7 @@ export function TemplateEditorModal({ isOpen, onClose, onApply, type, backendUrl
 
     return (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-background/80 backdrop-blur-sm">
-            <div className="w-full max-w-4xl h-[80vh] bg-card border border-border rounded-xl shadow-lg flex flex-col overflow-hidden">
+            <div className="w-full max-w-4xl h-[80vh] bg-card border border-border rounded-3xl shadow-lg flex flex-col overflow-hidden">
                 {}
                 <div className="flex items-center justify-between p-4 border-b border-border">
                     <div className="flex items-center gap-2">
@@ -331,7 +331,7 @@ export function TemplateEditorModal({ isOpen, onClose, onApply, type, backendUrl
             {}
             {showOverwriteConfirm && (
                 <div className="fixed inset-0 z-[60] flex items-center justify-center bg-background/80 backdrop-blur-sm">
-                    <div className="w-full max-w-sm bg-card border border-border rounded-xl shadow-lg p-6 space-y-4">
+                    <div className="w-full max-w-sm bg-card border border-border rounded-3xl shadow-lg p-6 space-y-4">
                         <div className="flex items-start gap-3">
                             <AlertTriangle className="h-5 w-5 text-amber-500 shrink-0 mt-0.5" />
                             <div>

--- a/src/components/UserNav.tsx
+++ b/src/components/UserNav.tsx
@@ -89,7 +89,7 @@ export function UserNav({ user }: UserNavProps) {
             </Button>
 
             {isOpen && (
-                <div className="absolute right-0 top-full mt-2 w-64 rounded-xl border border-border/50 bg-card/80 backdrop-blur-xl shadow-2xl p-1 z-50 animate-in fade-in zoom-in-95 duration-200">
+                <div className="absolute right-0 top-full mt-2 w-64 rounded-3xl border border-border/50 bg-card/80 backdrop-blur-xl shadow-2xl p-1 z-50 animate-in fade-in zoom-in-95 duration-200">
                     <div className="px-4 py-3 border-b border-border/50">
                         <p className="text-sm font-semibold text-foreground truncate">
                             {username}

--- a/src/components/modals/PostGenerationSuccessModal.tsx
+++ b/src/components/modals/PostGenerationSuccessModal.tsx
@@ -16,7 +16,7 @@ export function PostGenerationSuccessModal({ isOpen, onClose, readmeUrl, license
     return (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm animate-in fade-in duration-200">
             <div
-                className="relative w-full max-w-md rounded-xl border border-border bg-background shadow-2xl animate-in zoom-in-95 duration-200 p-6"
+                className="relative w-full max-w-md rounded-3xl border border-border bg-background shadow-2xl animate-in zoom-in-95 duration-200 p-6"
                 role="dialog"
                 aria-modal="true"
             >

--- a/src/components/tools/GitignoreBuilderTool.tsx
+++ b/src/components/tools/GitignoreBuilderTool.tsx
@@ -235,7 +235,7 @@ export function GitignoreBuilderTool({ user, backendUrl }: GitignoreBuilderToolP
 
                 <TabsContent value="composer" className="flex-1 flex flex-col gap-6 mt-0">
                     {}
-                    <div className="space-y-4 p-6 border rounded-xl bg-card">
+                    <div className="space-y-4 p-6 border rounded-3xl bg-card">
                         <div className="flex flex-col md:flex-row gap-4 justify-between items-start md:items-center">
                             <div>
                                 <h2 className="text-sm font-semibold flex items-center gap-2">
@@ -373,7 +373,7 @@ export function GitignoreBuilderTool({ user, backendUrl }: GitignoreBuilderToolP
 
                     {existingContent && (
                         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                            <label className={`cursor-pointer p-4 rounded-xl border-2 transition-all ${mergeStrategy === 'replace' ? 'border-brand bg-brand/5' : 'border-border hover:border-brand/50'}`}>
+                            <label className={`cursor-pointer p-4 rounded-3xl border-2 transition-all ${mergeStrategy === 'replace' ? 'border-brand bg-brand/5' : 'border-border hover:border-brand/50'}`}>
                                 <div className="flex items-center gap-3 mb-2">
                                     <input
                                         type="radio"
@@ -389,7 +389,7 @@ export function GitignoreBuilderTool({ user, backendUrl }: GitignoreBuilderToolP
                                 </p>
                             </label>
 
-                            <label className={`cursor-pointer p-4 rounded-xl border-2 transition-all ${mergeStrategy === 'append' ? 'border-brand bg-brand/5' : 'border-border hover:border-brand/50'}`}>
+                            <label className={`cursor-pointer p-4 rounded-3xl border-2 transition-all ${mergeStrategy === 'append' ? 'border-brand bg-brand/5' : 'border-border hover:border-brand/50'}`}>
                                 <div className="flex items-center gap-3 mb-2">
                                     <input
                                         type="radio"

--- a/src/components/tools/IssueCrafter.tsx
+++ b/src/components/tools/IssueCrafter.tsx
@@ -658,7 +658,7 @@ export function IssueCrafter({ user, backendUrl }: IssueCrafterProps) {
 
                     {}
                     <div className="space-y-6 flex flex-col h-full">
-                        <div className="rounded-xl border border-border bg-card text-card-foreground shadow-sm h-full flex flex-col overflow-hidden">
+                        <div className="rounded-3xl border border-border bg-card text-card-foreground shadow-sm h-full flex flex-col overflow-hidden">
                             <div className="p-4 border-b border-border flex justify-between items-center bg-muted/20">
                                 <h3 className="font-semibold leading-none tracking-tight flex items-center gap-2">
                                     Generated Issue

--- a/src/components/tools/PRMaker.tsx
+++ b/src/components/tools/PRMaker.tsx
@@ -681,7 +681,7 @@ export function PRMaker({ user }: PRMakerProps) {
 
                     {}
                     <div className="space-y-6 flex flex-col h-full">
-                        <div className="rounded-xl border border-border bg-card text-card-foreground shadow-sm h-full flex flex-col overflow-hidden">
+                        <div className="rounded-3xl border border-border bg-card text-card-foreground shadow-sm h-full flex flex-col overflow-hidden">
                             <div className="p-4 border-b border-border flex justify-between items-center bg-muted/20">
                                 <h3 className="font-semibold leading-none tracking-tight flex items-center gap-2">
                                     Generated PR

--- a/src/components/tools/ReadmeGenerator.tsx
+++ b/src/components/tools/ReadmeGenerator.tsx
@@ -668,7 +668,7 @@ export function ReadmeGenerator({ user }: ReadmeGeneratorProps) {
 
             {}
             <div className="space-y-6">
-                <div className="rounded-xl border border-border bg-card text-card-foreground shadow-sm h-full flex flex-col">
+                <div className="rounded-3xl border border-border bg-card text-card-foreground shadow-sm h-full flex flex-col">
                     <div className="p-4 border-b border-border flex justify-between items-center bg-muted/20">
                         <h3 className="font-semibold leading-none tracking-tight">Generated Readme</h3>
                         <div className="flex items-center gap-2">

--- a/src/components/tools/ReleaseCreator.tsx
+++ b/src/components/tools/ReleaseCreator.tsx
@@ -788,7 +788,7 @@ export function ReleaseCreator({ user, initialRepo = '' }: ReleaseCreatorProps) 
 
                     {}
                     <div className="space-y-6">
-                        <div className="rounded-xl border border-border bg-card text-card-foreground shadow-sm h-full flex flex-col">
+                        <div className="rounded-3xl border border-border bg-card text-card-foreground shadow-sm h-full flex flex-col">
                             <div className="p-4 border-b border-border flex justify-between items-center bg-muted/20">
                                 <h3 className="font-semibold leading-none tracking-tight">Generated Notes</h3>
                                 <div className="flex gap-2">

--- a/src/pages/changelog.astro
+++ b/src/pages/changelog.astro
@@ -104,7 +104,7 @@ try {
 
                 {
                     error && (
-                        <div class="rounded-xl border border-destructive/50 bg-destructive/10 p-6 text-center">
+                        <div class="rounded-3xl border border-destructive/50 bg-destructive/10 p-6 text-center">
                             <p class="text-sm text-destructive">{error}</p>
                         </div>
                     )
@@ -112,7 +112,7 @@ try {
 
                 {
                     !error && releases.length === 0 && (
-                        <div class="rounded-xl border border-border bg-card p-6 text-center">
+                        <div class="rounded-3xl border border-border bg-card p-6 text-center">
                             <p class="text-sm text-muted-foreground">
                                 No releases found.
                             </p>

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -55,7 +55,7 @@ const user = await getUser(Astro.cookies.get("app_auth_token")?.value);
                 <div class="grid gap-6 md:grid-cols-2">
                     <a
                         href="mailto:support@gitset.dev"
-                        class="flex flex-col items-center p-6 bg-card border border-border rounded-xl shadow-sm hover:shadow-md hover:border-brand/50 transition-all text-center group"
+                        class="flex flex-col items-center p-6 bg-card border border-border rounded-3xl shadow-sm hover:shadow-md hover:border-brand/50 transition-all text-center group"
                     >
                         <div
                             class="h-12 w-12 rounded-full bg-brand/10 flex items-center justify-center mb-4 group-hover:bg-brand/20 transition-colors"
@@ -94,7 +94,7 @@ const user = await getUser(Astro.cookies.get("app_auth_token")?.value);
                         href="https://github.com/gitset-dev/gitset-web/issues"
                         target="_blank"
                         rel="noreferrer"
-                        class="flex flex-col items-center p-6 bg-card border border-border rounded-xl shadow-sm hover:shadow-md hover:border-brand/50 transition-all text-center group"
+                        class="flex flex-col items-center p-6 bg-card border border-border rounded-3xl shadow-sm hover:shadow-md hover:border-brand/50 transition-all text-center group"
                     >
                         <div
                             class="h-12 w-12 rounded-full bg-brand/10 flex items-center justify-center mb-4 group-hover:bg-brand/20 transition-colors"
@@ -130,7 +130,7 @@ const user = await getUser(Astro.cookies.get("app_auth_token")?.value);
                 </div>
 
                 <div
-                    class="bg-card border border-border rounded-xl p-8 shadow-sm text-center space-y-4"
+                    class="bg-card border border-border rounded-3xl p-8 shadow-sm text-center space-y-4"
                 >
                     <h2 class="text-2xl font-semibold text-foreground">
                         Prefer reading the source?

--- a/src/pages/dashboard.astro
+++ b/src/pages/dashboard.astro
@@ -139,7 +139,7 @@ const joinedDate = new Date(
                     class="contents lg:col-span-4 lg:flex lg:flex-col lg:gap-6"
                 >
                     <div
-                        class="rounded-xl border border-border bg-card text-card-foreground shadow-sm overflow-hidden relative group"
+                        class="rounded-3xl border border-border bg-card text-card-foreground shadow-sm overflow-hidden relative group"
                     >
                         <div class="absolute top-4 right-4 z-10">
                             <a

--- a/src/pages/faq.astro
+++ b/src/pages/faq.astro
@@ -97,7 +97,7 @@ const faqs = [
                 <div class="space-y-4">
                     {
                         faqs.map((faq) => (
-                            <div class="rounded-xl border border-border bg-card shadow-sm hover:shadow-md transition-shadow">
+                            <div class="rounded-3xl border border-border bg-card shadow-sm hover:shadow-md transition-shadow">
                                 <div class="p-6 space-y-3">
                                     <h3 class="font-semibold text-lg leading-tight tracking-tight text-foreground">
                                         {faq.question}

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -148,18 +148,19 @@ const tools = [
         <main class="flex-1">
             {/* ── HERO ─────────────────────────────────────────────── */}
             <section class="relative overflow-hidden">
-                <div class="absolute inset-0 z-0 bg-background">
+                <div class="absolute inset-0 z-0">
                     <video
                         poster="/gitset-poster.jpg"
                         autoplay
                         loop
                         muted
                         playsinline
-                        class="w-full h-full object-cover opacity-25 dark:opacity-30 [clip-path:inset(0_23%)]"
+                        class="w-full h-full object-cover opacity-25 dark:opacity-30"
                     >
                         <source src="/gitset-video.webm" type="video/webm" />
                         <source src="/gitset-video.mp4" type="video/mp4" />
                     </video>
+                    <div class="absolute inset-0 bg-[linear-gradient(to_right,var(--background)_0%,transparent_25%,transparent_75%,var(--background)_100%)]"></div>
                     <div class="absolute inset-0 bg-gradient-to-b from-background/70 via-background/85 to-background"></div>
                 </div>
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -148,14 +148,14 @@ const tools = [
         <main class="flex-1">
             {/* ── HERO ─────────────────────────────────────────────── */}
             <section class="relative overflow-hidden">
-                <div class="absolute inset-0 z-0">
+                <div class="absolute inset-0 z-0 bg-background">
                     <video
                         poster="/gitset-poster.jpg"
                         autoplay
                         loop
                         muted
                         playsinline
-                        class="w-full h-full object-cover opacity-25 dark:opacity-30"
+                        class="w-full h-full object-cover opacity-25 dark:opacity-30 [clip-path:inset(0_23%)]"
                     >
                         <source src="/gitset-video.webm" type="video/webm" />
                         <source src="/gitset-video.mp4" type="video/mp4" />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -218,7 +218,7 @@ const tools = [
 
                 {/* ── LIVE-STYLE TERMINAL DEMO ─────────────────────── */}
                 <div class="relative z-10 container mx-auto px-4 pb-20 max-w-3xl">
-                    <div class="rounded-xl border border-border bg-[#0d1117] shadow-2xl shadow-black/40 overflow-hidden text-left">
+                    <div class="rounded-3xl border border-border bg-[#0d1117] shadow-2xl shadow-black/40 overflow-hidden text-left">
                         <div class="flex items-center gap-2 px-4 py-3 border-b border-white/10 bg-white/5">
                             <span class="h-3 w-3 rounded-full bg-[#ff5f57]"></span>
                             <span class="h-3 w-3 rounded-full bg-[#febc2e]"></span>
@@ -301,7 +301,7 @@ const tools = [
                     {tools.map((t) => (
                         <a
                             href={t.href}
-                            class="group rounded-xl border border-border bg-card p-5 hover:border-brand/60 hover:shadow-lg hover:shadow-brand/5 transition-all"
+                            class="group rounded-3xl border border-border bg-card p-5 hover:border-brand/60 hover:shadow-lg hover:shadow-brand/5 transition-all"
                         >
                             <div class="h-10 w-10 rounded-lg bg-brand/10 flex items-center justify-center mb-4 group-hover:bg-brand/15 transition-colors">
                                 <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-brand" set:html={t.icon} />

--- a/src/pages/login.astro
+++ b/src/pages/login.astro
@@ -28,7 +28,7 @@ const error = Astro.url.searchParams.get("error");
 
         <main class="flex flex-1 items-center justify-center p-4 sm:p-6">
             <div
-                class="relative w-full max-w-md transform overflow-hidden rounded-xl border border-border bg-card p-6 shadow-2xl"
+                class="relative w-full max-w-md transform overflow-hidden rounded-3xl border border-border bg-card p-6 shadow-2xl"
             >
                 <div class="flex flex-col items-center text-center">
                     <div

--- a/src/pages/privacy.astro
+++ b/src/pages/privacy.astro
@@ -132,7 +132,7 @@ const sections: { title: string; paragraphs: string[]; bullets?: string[] }[] = 
                 </div>
 
                 <div
-                    class="rounded-xl border border-border bg-card shadow-sm p-8 space-y-8"
+                    class="rounded-3xl border border-border bg-card shadow-sm p-8 space-y-8"
                 >
                     {sections.map((s) => (
                         <div class="space-y-3">

--- a/src/pages/terms.astro
+++ b/src/pages/terms.astro
@@ -157,7 +157,7 @@ const sections: { title: string; paragraphs: string[]; bullets?: string[] }[] = 
                 </div>
 
                 <div
-                    class="rounded-xl border border-border bg-card shadow-sm p-8 space-y-8"
+                    class="rounded-3xl border border-border bg-card shadow-sm p-8 space-y-8"
                 >
                     {sections.map((s) => (
                         <div class="space-y-3">

--- a/src/pages/tools/commit-messages-generator.astro
+++ b/src/pages/tools/commit-messages-generator.astro
@@ -323,7 +323,7 @@ const BACKEND_URL = "/api/commit";
 
                 <div class="space-y-6">
                     <div
-                        class="rounded-xl border border-border bg-card text-card-foreground shadow-sm h-full flex flex-col"
+                        class="rounded-3xl border border-border bg-card text-card-foreground shadow-sm h-full flex flex-col"
                     >
                         <div
                             class="p-4 border-b border-border flex justify-between items-center"

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -117,9 +117,9 @@
   .dark {
     --background: hsl(30 8% 7%);
     --foreground: hsl(40 15% 95%);
-    --card: hsl(30 8% 9%);
+    --card: hsl(30 8% 6%);
     --card-foreground: hsl(40 15% 95%);
-    --popover: hsl(30 8% 9%);
+    --popover: hsl(30 8% 6%);
     --popover-foreground: hsl(40 15% 95%);
     --primary: hsl(40 15% 95%);
     --primary-foreground: hsl(30 10% 12%);


### PR DESCRIPTION
## Summary
- Darkened the dark-theme `--card`/`--popover` token (`hsl(30 8% 9%)` → `hsl(30 8% 6%)` in `src/styles/global.css`) so the sticky header, hero pills, and every `bg-card` panel read flush against the homepage hero video instead of a lighter seam. Light theme untouched.
- The hero video (`gitset-video.webm`/`.mp4`) turned out to bake in solid `rgb(35,39,43)` padding bars around its centered logo animation — a different color family entirely from the site's near-black tokens. Rather than crop the asset, added a second horizontal gradient overlay in `src/pages/index.astro` (background-solid at the edges, transparent in the middle) that blends those bars into `--background`. The video itself is untouched — no cropping, no resolution changes.
- Standardized all 29 `rounded-xl` occurrences across 22 files (cards, modals, tool-result panels, static pages, the homepage terminal mockup) to `rounded-3xl` for a consistent corner radius across the app. Buttons/inputs/pills left as-is for a follow-up pass.

## Why
Visual QA pass: the dark-theme near-black surfaces didn't read as one continuous tone next to the hero video, and the card/panel radius was inconsistent with the rest of the UI (mix of `rounded-xl`, `rounded-lg`, `rounded-full`).

## Test plan
- [x] `astro check` — 0 errors / 0 warnings (same as baseline)
- [x] Manual visual check in dark mode at a normal desktop width and an extreme ultra-wide/short viewport (2200x650, the worst case for the video's `object-cover` crop) — no seam at the header/hero boundary, no visible gray bars at the video's edges, no hard crop/slice line
- [ ] Light theme — intentionally unmodified, not in scope for this pass

Closes gitset-dev/gitset#35
