### PR TITLE
Show text labels on the desktop header's Tools and AI Providers buttons

### DIFF
--- a/src/components/SiteHeader.tsx
+++ b/src/components/SiteHeader.tsx
@@ -186,10 +186,10 @@ export function SiteHeader({ showBackButton = true, user }: SiteHeaderProps) {
                                 <button
                                     onClick={() => setIsToolsOpen(!isToolsOpen)}
                                     aria-label="Tools"
-                                    title="Tools"
-                                    className="inline-flex h-9 w-9 items-center justify-center rounded-md border border-border text-muted-foreground transition-colors hover:text-foreground hover:border-foreground/40"
+                                    className="inline-flex h-9 items-center gap-2 rounded-md border border-border px-3 text-sm font-medium text-muted-foreground transition-colors hover:text-foreground hover:border-foreground/40"
                                 >
                                     <Hammer className="h-4 w-4" />
+                                    Tools
                                 </button>
                                 {isToolsOpen && (
                                     <div className="absolute right-0 top-full mt-2 w-48 rounded-md border border-border bg-card p-1 shadow-lg z-50">
@@ -226,8 +226,7 @@ export function SiteHeader({ showBackButton = true, user }: SiteHeaderProps) {
                             <div className="hidden md:flex items-center gap-6">
                                 <ProviderKeysManager
                                     triggerLabel="AI Providers"
-                                    iconOnly
-                                    triggerClassName="inline-flex h-9 w-9 items-center justify-center rounded-md border border-border text-muted-foreground transition-colors hover:text-foreground hover:border-foreground/40"
+                                    triggerClassName="inline-flex h-9 items-center gap-2 rounded-md border border-border px-3 text-sm font-medium text-muted-foreground transition-colors hover:text-foreground hover:border-foreground/40"
                                 />
                                 <UserNav user={user as any} />
                             </div>


### PR DESCRIPTION
## Summary
- Desktop header's Tools (hammer icon) and AI Providers (key icon) buttons were icon-only 36×36 squares, discoverable only via a hover tooltip.
- Both now show their name next to the icon in `src/components/SiteHeader.tsx`, matching how the mobile menu and the header's own Login control already render (icon + visible text).
- AI Providers keeps the name already used everywhere else for this feature (dashboard trigger, mobile menu trigger, `/pricing` copy) instead of introducing "BYOAI" as a second name for the same destination.

## Why
The mobile menu already got this right; the desktop header was the odd one out, relying on a `title` tooltip that isn't discoverable on touch/no-hover devices and isn't visible at a glance.

## Test plan
- [x] `astro check` — 0 errors / 0 warnings
- [x] Manual check on the running dev server: both buttons render icon + text at desktop width, styling consistent with the Login control next to them
- [x] Tools dropdown still opens/closes correctly (all 8 tool links present) — behavior unchanged, only the trigger's visual treatment changed

Closes gitset-dev/gitset#37
