### PR TITLE
Add Knowledge Mapper dashboard

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -31,6 +31,7 @@ export function Footer() {
                         <a href="/tools/gitignore-builder" className="text-sm text-muted-foreground hover:text-foreground transition-colors">Gitignore Builder</a>
                         <a href="/tools/repo-profiler" className="text-sm text-muted-foreground hover:text-foreground transition-colors">Repo Profiler</a>
                         <a href="/tools/backup-automator" className="text-sm text-muted-foreground hover:text-foreground transition-colors">Backup Automator</a>
+                        <a href="/tools/knowledge-mapper" className="text-sm text-muted-foreground hover:text-foreground transition-colors">Knowledge Mapper</a>
                     </div>
 
                     <div className="flex flex-col gap-2 2xl:justify-self-center">

--- a/src/components/SiteHeader.tsx
+++ b/src/components/SiteHeader.tsx
@@ -24,6 +24,7 @@ import {
     LogIn,
     LogOut,
     ChevronDown,
+    Network,
 } from "lucide-react";
 
 const GitBranchMinus = (props: React.SVGProps<SVGSVGElement>) => (
@@ -115,6 +116,11 @@ export function SiteHeader({ showBackButton = true, user }: SiteHeaderProps) {
             name: "Repo Profiler",
             href: "/tools/repo-profiler",
             icon: Github,
+        },
+        {
+            name: "Knowledge Mapper",
+            href: "/tools/knowledge-mapper",
+            icon: Network,
         },
     ];
 

--- a/src/components/tools/KnowledgeMapper.tsx
+++ b/src/components/tools/KnowledgeMapper.tsx
@@ -4,7 +4,7 @@ import { ghFetch } from '@/lib/githubProxy';
 import {
     Loader2, Copy, Check, ExternalLink, RefreshCw, Search, Terminal,
     FileText, ChevronDown, ChevronRight, CheckCircle2, AlertTriangle,
-    Network, BookOpen, ShieldCheck, Coins,
+    Network, BookOpen, ShieldCheck, Coins, Workflow, GitPullRequest, XCircle,
 } from 'lucide-react';
 
 interface User {
@@ -39,6 +39,15 @@ interface Drift {
     truncated: boolean;
 }
 
+interface Automation {
+    status: 'none' | 'configured';
+    mode?: 'push' | 'releases' | 'weekly' | 'custom';
+    branch?: string;
+    nextRunAt?: string | null;
+    lastRun?: { conclusion: string | null; status: string; at: string; url: string } | null;
+    updatePr?: { number: number; url: string } | null;
+}
+
 type Status = 'idle' | 'loading' | 'missing' | 'loaded' | 'error';
 
 const KNOWLEDGE_DIR = 'docs/gitset-knowledge';
@@ -54,6 +63,43 @@ function moduleKeyFor(filePath: string): string {
 
 function decodeBase64Utf8(base64: string): string {
     return decodeURIComponent(escape(atob(base64.replace(/\n/g, ''))));
+}
+
+const WORKFLOW_FILE = '.github/workflows/gitset-knowledge.yml';
+
+function parseWorkflowTrigger(yaml: string): { mode: Automation['mode']; branch?: string; cron?: string } {
+    if (/\brelease:/.test(yaml) && /types:\s*\[published\]/.test(yaml)) return { mode: 'releases' };
+    const cron = yaml.match(/cron:\s*'([^']+)'/);
+    if (/\bschedule:/.test(yaml) && cron) return { mode: 'weekly', cron: cron[1] };
+    const branches = yaml.match(/\bpush:\s*\r?\n\s*branches:\s*\[([^\]]+)\]/);
+    if (branches) return { mode: 'push', branch: branches[1].trim() };
+    return { mode: 'custom' };
+}
+
+function nextCronRun(cron: string): Date | null {
+    const parts = cron.trim().split(/\s+/);
+    if (parts.length !== 5 || parts[2] !== '*' || parts[3] !== '*') return null;
+    const minute = parseInt(parts[0], 10);
+    const hour = parseInt(parts[1], 10);
+    if (Number.isNaN(minute) || Number.isNaN(hour)) return null;
+    const dow = parts[4] === '*' ? null : parseInt(parts[4], 10);
+    if (parts[4] !== '*' && Number.isNaN(dow)) return null;
+    const now = new Date();
+    const base = Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate(), hour, minute, 0);
+    for (let i = 0; i < 8; i += 1) {
+        const candidate = new Date(base + i * 86400000);
+        if (candidate.getTime() <= now.getTime()) continue;
+        if (dow === null || candidate.getUTCDay() === dow) return candidate;
+    }
+    return null;
+}
+
+function relativeFuture(date: Date): string {
+    const mins = Math.round((date.getTime() - Date.now()) / 60000);
+    if (mins < 60) return `in ${Math.max(mins, 1)} min`;
+    const hours = Math.round(mins / 60);
+    if (hours < 48) return `in ${hours}h`;
+    return `in ${Math.round(hours / 24)} days`;
 }
 
 function relativeTime(iso: string): string {
@@ -99,14 +145,64 @@ export function KnowledgeMapper({ user }: { user: User }) {
     const [state, setState] = useState<KnowledgeState | null>(null);
     const [branch, setBranch] = useState('main');
     const [drift, setDrift] = useState<Drift | null>(null);
+    const [automation, setAutomation] = useState<Automation | null>(null);
     const [search, setSearch] = useState('');
     const [expanded, setExpanded] = useState<Set<string>>(new Set());
+
+    const loadAutomation = async (repoFullName: string, defaultBranch: string) => {
+        try {
+            const wfRes = await ghFetch(`/repos/${repoFullName}/contents/${WORKFLOW_FILE}?ref=${defaultBranch}`);
+            if (wfRes.status === 404) {
+                setAutomation({ status: 'none' });
+                return;
+            }
+            if (!wfRes.ok) return;
+            const wfData = await wfRes.json();
+            const trigger = parseWorkflowTrigger(decodeBase64Utf8(wfData.content));
+
+            let lastRun: Automation['lastRun'] = null;
+            const runsRes = await ghFetch(`/repos/${repoFullName}/actions/workflows/gitset-knowledge.yml/runs?per_page=1`);
+            if (runsRes.ok) {
+                const runs = await runsRes.json();
+                const run = (runs.workflow_runs || [])[0];
+                if (run) {
+                    lastRun = {
+                        conclusion: run.conclusion,
+                        status: run.status,
+                        at: run.updated_at || run.created_at,
+                        url: run.html_url,
+                    };
+                }
+            }
+
+            let updatePr: Automation['updatePr'] = null;
+            const owner = repoFullName.split('/')[0];
+            const prRes = await ghFetch(`/repos/${repoFullName}/pulls?state=open&head=${encodeURIComponent(`${owner}:gitset/knowledge-update`)}`);
+            if (prRes.ok) {
+                const prs = await prRes.json();
+                if (Array.isArray(prs) && prs[0]) updatePr = { number: prs[0].number, url: prs[0].html_url };
+            }
+
+            const next = trigger.cron ? nextCronRun(trigger.cron) : null;
+            setAutomation({
+                status: 'configured',
+                mode: trigger.mode,
+                branch: trigger.branch,
+                nextRunAt: next ? next.toISOString() : null,
+                lastRun,
+                updatePr,
+            });
+        } catch {
+            setAutomation(null);
+        }
+    };
 
     const load = async (repoFullName: string) => {
         setStatus('loading');
         setError(null);
         setState(null);
         setDrift(null);
+        setAutomation(null);
         setExpanded(new Set());
         try {
             let defaultBranch = 'main';
@@ -128,6 +224,7 @@ export function KnowledgeMapper({ user }: { user: User }) {
             const parsed: KnowledgeState = JSON.parse(decodeBase64Utf8(stateData.content));
             setState(parsed);
             setStatus('loaded');
+            loadAutomation(repoFullName, defaultBranch);
 
             if (parsed.commit) {
                 const cmpRes = await ghFetch(`/repos/${repoFullName}/compare/${parsed.commit}...${defaultBranch}`);
@@ -162,6 +259,7 @@ export function KnowledgeMapper({ user }: { user: User }) {
             setStatus('idle');
             setState(null);
             setDrift(null);
+            setAutomation(null);
         }
     }, [repo]);
 
@@ -282,6 +380,9 @@ export function KnowledgeMapper({ user }: { user: User }) {
                             Review the generated <code>{KNOWLEDGE_DIR}/</code> and <code>AGENTS.md</code>, then commit and push them like any other change.
                             The knowledge base is meant to live in git — that's how agents, teammates and this dashboard find it.
                         </p>
+                        <p className="text-xs text-muted-foreground">
+                            Optional: <code>gitset knowledge automate</code> writes a CI workflow (per-push, per-release or weekly) that keeps it fresh and opens a review PR when something actually changed.
+                        </p>
                     </section>
 
                     <button
@@ -357,6 +458,71 @@ export function KnowledgeMapper({ user }: { user: User }) {
                             </div>
                             <p className="text-xs text-muted-foreground">Refresh only what changed (cached summaries are reused):</p>
                             <CopyableCommand command="gitset knowledge update" />
+                        </div>
+                    )}
+
+                    {automation && automation.status === 'none' && (
+                        <div className="space-y-2 rounded-lg border border-border bg-card p-4">
+                            <div className="flex items-start gap-2">
+                                <Workflow className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
+                                <div className="text-sm">
+                                    <p className="font-medium">CI automation is off</p>
+                                    <p className="text-xs text-muted-foreground">Let CI keep this knowledge base fresh — it opens a review PR only when mapped source actually changed. Choose per-push, per-release or weekly:</p>
+                                </div>
+                            </div>
+                            <CopyableCommand command="gitset knowledge automate" />
+                        </div>
+                    )}
+
+                    {automation && automation.status === 'configured' && (
+                        <div className="space-y-2 rounded-lg border border-brand/30 bg-brand/5 p-4">
+                            <div className="flex items-start gap-2">
+                                <Workflow className="mt-0.5 h-4 w-4 shrink-0 text-brand" />
+                                <div className="text-sm">
+                                    <p className="font-medium">CI automation active</p>
+                                    <p className="text-xs text-muted-foreground">
+                                        {automation.mode === 'push' && `Runs on every push to ${automation.branch || 'the default branch'} that touches mapped source — pushes with no mapped changes cost zero AI calls.`}
+                                        {automation.mode === 'releases' && 'Runs whenever a release is published.'}
+                                        {automation.mode === 'weekly' && (automation.nextRunAt
+                                            ? `Runs weekly — next run ${new Date(automation.nextRunAt).toLocaleString()} (${relativeFuture(new Date(automation.nextRunAt))}).`
+                                            : 'Runs on a weekly schedule.')}
+                                        {automation.mode === 'custom' && 'Custom trigger — the workflow file was edited manually.'}
+                                    </p>
+                                </div>
+                            </div>
+                            <div className="flex flex-wrap items-center gap-2 pl-6">
+                                {automation.lastRun && (
+                                    <a
+                                        href={automation.lastRun.url}
+                                        target="_blank"
+                                        rel="noopener noreferrer"
+                                        className="inline-flex items-center gap-1.5 rounded-full bg-background px-2.5 py-1 text-[11px] font-medium hover:bg-accent"
+                                    >
+                                        {automation.lastRun.status !== 'completed'
+                                            ? <Loader2 className="h-3 w-3 animate-spin text-muted-foreground" />
+                                            : automation.lastRun.conclusion === 'success'
+                                                ? <CheckCircle2 className="h-3 w-3 text-brand" />
+                                                : <XCircle className="h-3 w-3 text-red-500" />}
+                                        Last run: {automation.lastRun.status !== 'completed' ? 'running' : automation.lastRun.conclusion} · {relativeTime(automation.lastRun.at)}
+                                        <ExternalLink className="h-3 w-3 text-muted-foreground" />
+                                    </a>
+                                )}
+                                {!automation.lastRun && (
+                                    <span className="rounded-full bg-background px-2.5 py-1 text-[11px] text-muted-foreground">No runs yet</span>
+                                )}
+                                {automation.updatePr && (
+                                    <a
+                                        href={automation.updatePr.url}
+                                        target="_blank"
+                                        rel="noopener noreferrer"
+                                        className="inline-flex items-center gap-1.5 rounded-full bg-amber-500/10 px-2.5 py-1 text-[11px] font-medium text-amber-700 hover:bg-amber-500/20 dark:text-amber-400"
+                                    >
+                                        <GitPullRequest className="h-3 w-3" />
+                                        Update PR #{automation.updatePr.number} awaiting review
+                                        <ExternalLink className="h-3 w-3" />
+                                    </a>
+                                )}
+                            </div>
                         </div>
                     )}
 

--- a/src/components/tools/KnowledgeMapper.tsx
+++ b/src/components/tools/KnowledgeMapper.tsx
@@ -1,0 +1,453 @@
+import React, { useState, useEffect, useMemo } from 'react';
+import { RepositorySelector } from '../RepositorySelector';
+import { ghFetch } from '@/lib/githubProxy';
+import {
+    Loader2, Copy, Check, ExternalLink, RefreshCw, Search, Terminal,
+    FileText, ChevronDown, ChevronRight, CheckCircle2, AlertTriangle,
+    Network, BookOpen, ShieldCheck, Coins,
+} from 'lucide-react';
+
+interface User {
+    gitsetKey: string;
+    githubOauthToken?: string | null;
+    plan?: string;
+}
+
+interface FileSummary {
+    path: string;
+    purpose: string;
+    exports: string[];
+    dependencies: string[];
+    notes: string;
+}
+
+interface KnowledgeState {
+    version: number;
+    generatedAt: string;
+    provider: string | null;
+    model: string | null;
+    tag: string | null;
+    commit: string | null;
+    fileHashes: Record<string, string>;
+    moduleSummaries: Record<string, FileSummary[] | string>;
+}
+
+interface Drift {
+    aheadBy: number;
+    changedMapped: string[];
+    byModule: Record<string, number>;
+    truncated: boolean;
+}
+
+type Status = 'idle' | 'loading' | 'missing' | 'loaded' | 'error';
+
+const KNOWLEDGE_DIR = 'docs/gitset-knowledge';
+const DOC_FILES = ['index.md', 'architecture.md', 'developer-guide.md', 'commands-and-workflows.md', 'module-map.md'];
+const CONTAINER_DIRS = new Set(['src', 'lib', 'app', 'packages', 'pkg', 'internal', 'cmd', 'api', 'server', 'client']);
+
+function moduleKeyFor(filePath: string): string {
+    const segments = filePath.split('/');
+    if (segments.length === 1) return '(root)';
+    if (CONTAINER_DIRS.has(segments[0]) && segments.length > 2) return `${segments[0]}/${segments[1]}`;
+    return segments[0];
+}
+
+function decodeBase64Utf8(base64: string): string {
+    return decodeURIComponent(escape(atob(base64.replace(/\n/g, ''))));
+}
+
+function relativeTime(iso: string): string {
+    const then = new Date(iso).getTime();
+    if (Number.isNaN(then)) return iso;
+    const mins = Math.round((Date.now() - then) / 60000);
+    if (mins < 1) return 'just now';
+    if (mins < 60) return `${mins} min ago`;
+    const hours = Math.round(mins / 60);
+    if (hours < 48) return `${hours}h ago`;
+    const days = Math.round(hours / 24);
+    if (days < 60) return `${days} days ago`;
+    return new Date(iso).toLocaleDateString();
+}
+
+function CopyableCommand({ command }: { command: string }) {
+    const [copied, setCopied] = useState(false);
+    return (
+        <div className="flex items-center gap-2 rounded-md bg-muted px-3 py-2 font-mono text-xs">
+            <Terminal className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+            <span className="flex-1 overflow-x-auto whitespace-nowrap">{command}</span>
+            <button
+                type="button"
+                onClick={() => {
+                    navigator.clipboard.writeText(command).then(() => {
+                        setCopied(true);
+                        setTimeout(() => setCopied(false), 2000);
+                    });
+                }}
+                className="shrink-0 rounded p-1 hover:bg-background"
+                aria-label={`Copy ${command}`}
+            >
+                {copied ? <Check className="h-3.5 w-3.5 text-brand" /> : <Copy className="h-3.5 w-3.5 text-muted-foreground" />}
+            </button>
+        </div>
+    );
+}
+
+export function KnowledgeMapper({ user }: { user: User }) {
+    const [repo, setRepo] = useState('');
+    const [status, setStatus] = useState<Status>('idle');
+    const [error, setError] = useState<string | null>(null);
+    const [state, setState] = useState<KnowledgeState | null>(null);
+    const [branch, setBranch] = useState('main');
+    const [drift, setDrift] = useState<Drift | null>(null);
+    const [search, setSearch] = useState('');
+    const [expanded, setExpanded] = useState<Set<string>>(new Set());
+
+    const load = async (repoFullName: string) => {
+        setStatus('loading');
+        setError(null);
+        setState(null);
+        setDrift(null);
+        setExpanded(new Set());
+        try {
+            let defaultBranch = 'main';
+            const repoRes = await ghFetch(`/repos/${repoFullName}`);
+            if (repoRes.ok) {
+                const repoData = await repoRes.json();
+                defaultBranch = repoData.default_branch || 'main';
+            }
+            setBranch(defaultBranch);
+
+            const stateRes = await ghFetch(`/repos/${repoFullName}/contents/${KNOWLEDGE_DIR}/.state.json?ref=${defaultBranch}`);
+            if (stateRes.status === 404) {
+                setStatus('missing');
+                return;
+            }
+            if (!stateRes.ok) throw new Error(`GitHub returned ${stateRes.status} while looking for the knowledge base.`);
+
+            const stateData = await stateRes.json();
+            const parsed: KnowledgeState = JSON.parse(decodeBase64Utf8(stateData.content));
+            setState(parsed);
+            setStatus('loaded');
+
+            if (parsed.commit) {
+                const cmpRes = await ghFetch(`/repos/${repoFullName}/compare/${parsed.commit}...${defaultBranch}`);
+                if (cmpRes.ok) {
+                    const cmp = await cmpRes.json();
+                    const mapped = new Set(Object.keys(parsed.fileHashes || {}));
+                    const changedMapped: string[] = [];
+                    const byModule: Record<string, number> = {};
+                    for (const f of cmp.files || []) {
+                        if (!mapped.has(f.filename)) continue;
+                        changedMapped.push(f.filename);
+                        const mod = moduleKeyFor(f.filename);
+                        byModule[mod] = (byModule[mod] || 0) + 1;
+                    }
+                    setDrift({
+                        aheadBy: cmp.ahead_by || 0,
+                        changedMapped,
+                        byModule,
+                        truncated: (cmp.files || []).length >= 300,
+                    });
+                }
+            }
+        } catch (e: any) {
+            setError(e.message || 'Failed to load the knowledge base.');
+            setStatus('error');
+        }
+    };
+
+    useEffect(() => {
+        if (repo && repo.includes('/')) load(repo);
+        else {
+            setStatus('idle');
+            setState(null);
+            setDrift(null);
+        }
+    }, [repo]);
+
+    const modules = useMemo(() => {
+        if (!state) return [];
+        const entries = Object.entries(state.moduleSummaries || {});
+        const term = search.trim().toLowerCase();
+        return entries
+            .map(([name, summary]) => {
+                const files = Array.isArray(summary) ? summary : [];
+                const raw = typeof summary === 'string' ? summary : null;
+                return { name, files, raw, driftCount: drift?.byModule[name] || 0 };
+            })
+            .filter((m) => {
+                if (!term) return true;
+                if (m.name.toLowerCase().includes(term)) return true;
+                return m.files.some((f) => f.path.toLowerCase().includes(term) || f.purpose.toLowerCase().includes(term));
+            })
+            .sort((a, b) => b.driftCount - a.driftCount || a.name.localeCompare(b.name));
+    }, [state, drift, search]);
+
+    const toggleModule = (name: string) => {
+        setExpanded((prev) => {
+            const next = new Set(prev);
+            if (next.has(name)) next.delete(name);
+            else next.add(name);
+            return next;
+        });
+    };
+
+    const mappedFileCount = state ? Object.keys(state.fileHashes || {}).length : 0;
+    const moduleCount = state ? Object.keys(state.moduleSummaries || {}).length : 0;
+
+    return (
+        <div className="space-y-6">
+            <div className="space-y-2">
+                <label className="text-sm font-medium leading-none">Repository</label>
+                <RepositorySelector
+                    githubToken={user.githubOauthToken}
+                    value={repo}
+                    onChange={setRepo}
+                    placeholder="Select repository"
+                />
+            </div>
+
+            {status === 'idle' && (
+                <div className="rounded-lg border border-border bg-card p-8 text-center text-muted-foreground">
+                    <Network className="mx-auto mb-3 h-10 w-10 opacity-20" />
+                    <p className="text-sm">Select a repository to view its knowledge base — or set one up in two minutes.</p>
+                </div>
+            )}
+
+            {status === 'loading' && (
+                <div className="flex items-center justify-center gap-2 rounded-lg border border-border bg-card p-8 text-muted-foreground">
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                    <span className="text-sm">Checking {repo} for a knowledge base…</span>
+                </div>
+            )}
+
+            {status === 'error' && (
+                <div className="flex items-start gap-2 rounded-lg border border-red-200 bg-red-500/10 p-4 text-sm text-red-600 dark:text-red-400">
+                    <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+                    <span>{error}</span>
+                </div>
+            )}
+
+            {status === 'missing' && (
+                <div className="space-y-4">
+                    <div className="rounded-lg border border-brand/30 bg-brand/5 p-4">
+                        <p className="text-sm font-medium">No knowledge base in this repository yet.</p>
+                        <p className="mt-1 text-xs text-muted-foreground">
+                            Knowledge Mapper builds <code>{KNOWLEDGE_DIR}/</code> — an always-current map of your codebase
+                            (architecture, modules, workflows) that both developers and AI agents read before touching your code.
+                            It is generated from source code, never from existing docs, so it can't inherit their drift.
+                        </p>
+                    </div>
+
+                    <div className="grid gap-3 sm:grid-cols-3">
+                        <div className="flex items-start gap-2 rounded-lg border border-border bg-card p-3">
+                            <ShieldCheck className="mt-0.5 h-4 w-4 shrink-0 text-brand" />
+                            <p className="text-xs text-muted-foreground"><span className="font-medium text-foreground">Private by design.</span> Runs on your machine with your own AI key. Secrets are redacted locally before any AI call.</p>
+                        </div>
+                        <div className="flex items-start gap-2 rounded-lg border border-border bg-card p-3">
+                            <Coins className="mt-0.5 h-4 w-4 shrink-0 text-brand" />
+                            <p className="text-xs text-muted-foreground"><span className="font-medium text-foreground">Cost-honest.</span> Shows the exact call/token estimate and asks before spending. Typical repo: cents.</p>
+                        </div>
+                        <div className="flex items-start gap-2 rounded-lg border border-border bg-card p-3">
+                            <RefreshCw className="mt-0.5 h-4 w-4 shrink-0 text-brand" />
+                            <p className="text-xs text-muted-foreground"><span className="font-medium text-foreground">Incremental.</span> Updates re-analyze only what changed — you never pay twice for the same code.</p>
+                        </div>
+                    </div>
+
+                    <section className="space-y-3 rounded-lg border border-border bg-card p-5">
+                        <h2 className="flex items-center gap-2 text-sm font-semibold">
+                            <span className="flex h-6 w-6 items-center justify-center rounded-full bg-brand/10 text-xs text-brand">1</span>
+                            Install the CLI and connect your AI key
+                        </h2>
+                        <CopyableCommand command="npm i -g @gitset-dev/cli" />
+                        <CopyableCommand command="gitset config" />
+                    </section>
+
+                    <section className="space-y-3 rounded-lg border border-border bg-card p-5">
+                        <h2 className="flex items-center gap-2 text-sm font-semibold">
+                            <span className="flex h-6 w-6 items-center justify-center rounded-full bg-brand/10 text-xs text-brand">2</span>
+                            Preview the plan — free, zero AI calls
+                        </h2>
+                        <p className="text-xs text-muted-foreground">Inside your repository, see exactly what would be analyzed and what it would cost:</p>
+                        <CopyableCommand command="gitset knowledge scan" />
+                    </section>
+
+                    <section className="space-y-3 rounded-lg border border-border bg-card p-5">
+                        <h2 className="flex items-center gap-2 text-sm font-semibold">
+                            <span className="flex h-6 w-6 items-center justify-center rounded-full bg-brand/10 text-xs text-brand">3</span>
+                            Generate, review, commit
+                        </h2>
+                        <CopyableCommand command="gitset knowledge generate" />
+                        <p className="text-xs text-muted-foreground">
+                            Review the generated <code>{KNOWLEDGE_DIR}/</code> and <code>AGENTS.md</code>, then commit and push them like any other change.
+                            The knowledge base is meant to live in git — that's how agents, teammates and this dashboard find it.
+                        </p>
+                    </section>
+
+                    <button
+                        type="button"
+                        onClick={() => load(repo)}
+                        className="inline-flex items-center gap-2 rounded-md border border-input bg-background px-3 py-2 text-sm font-medium hover:bg-accent"
+                    >
+                        <RefreshCw className="h-3.5 w-3.5" />
+                        Already pushed it? Refresh
+                    </button>
+                </div>
+            )}
+
+            {status === 'loaded' && state && (
+                <div className="space-y-4">
+                    <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+                        <div className="rounded-lg border border-border bg-card p-4">
+                            <p className="text-xs text-muted-foreground">Generated</p>
+                            <p className="mt-1 text-sm font-semibold" title={state.generatedAt}>{relativeTime(state.generatedAt)}</p>
+                        </div>
+                        <div className="rounded-lg border border-border bg-card p-4">
+                            <p className="text-xs text-muted-foreground">Model</p>
+                            <p className="mt-1 truncate text-sm font-semibold" title={`${state.provider} / ${state.model}`}>{state.provider}{state.model ? ` / ${state.model}` : ''}</p>
+                        </div>
+                        <div className="rounded-lg border border-border bg-card p-4">
+                            <p className="text-xs text-muted-foreground">Coverage</p>
+                            <p className="mt-1 text-sm font-semibold">{mappedFileCount} files · {moduleCount} modules</p>
+                        </div>
+                        <div className="rounded-lg border border-border bg-card p-4">
+                            <p className="text-xs text-muted-foreground">Snapshot</p>
+                            <p className="mt-1 truncate text-sm font-semibold" title={state.commit || undefined}>{state.tag || (state.commit ? state.commit.slice(0, 7) : '—')}</p>
+                        </div>
+                    </div>
+
+                    {drift === null && state.commit === null && (
+                        <div className="flex items-start gap-2 rounded-lg border border-border bg-card p-4 text-xs text-muted-foreground">
+                            <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+                            <span>This snapshot predates drift tracking. Regenerate with the latest CLI to enable it.</span>
+                        </div>
+                    )}
+
+                    {drift && drift.changedMapped.length === 0 && (
+                        <div className="flex items-start gap-2 rounded-lg border border-brand/30 bg-brand/5 p-4">
+                            <CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0 text-brand" />
+                            <div className="text-sm">
+                                <p className="font-medium">Up to date</p>
+                                <p className="text-xs text-muted-foreground">
+                                    {drift.aheadBy === 0
+                                        ? 'No commits since this knowledge base was generated.'
+                                        : `${drift.aheadBy} commit${drift.aheadBy === 1 ? '' : 's'} since generation, but none touched mapped source files.`}
+                                </p>
+                            </div>
+                        </div>
+                    )}
+
+                    {drift && drift.changedMapped.length > 0 && (
+                        <div className="space-y-3 rounded-lg border border-amber-300/50 bg-amber-500/5 p-4">
+                            <div className="flex items-start gap-2">
+                                <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-500" />
+                                <div className="text-sm">
+                                    <p className="font-medium">Drift detected</p>
+                                    <p className="text-xs text-muted-foreground">
+                                        {drift.changedMapped.length}{drift.truncated ? '+' : ''} mapped file{drift.changedMapped.length === 1 ? '' : 's'} changed across {drift.aheadBy} commit{drift.aheadBy === 1 ? '' : 's'} since generation.
+                                    </p>
+                                </div>
+                            </div>
+                            <div className="flex flex-wrap gap-1.5">
+                                {Object.entries(drift.byModule).sort((a, b) => b[1] - a[1]).map(([mod, count]) => (
+                                    <span key={mod} className="rounded-full bg-amber-500/10 px-2 py-0.5 font-mono text-[11px] text-amber-700 dark:text-amber-400">
+                                        {mod} · {count}
+                                    </span>
+                                ))}
+                            </div>
+                            <p className="text-xs text-muted-foreground">Refresh only what changed (cached summaries are reused):</p>
+                            <CopyableCommand command="gitset knowledge update" />
+                        </div>
+                    )}
+
+                    <div className="flex flex-wrap items-center gap-2">
+                        {DOC_FILES.map((f) => (
+                            <a
+                                key={f}
+                                href={`https://github.com/${repo}/blob/${branch}/${KNOWLEDGE_DIR}/${f}`}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="inline-flex items-center gap-1.5 rounded-md border border-input bg-background px-2.5 py-1.5 text-xs font-medium hover:bg-accent"
+                            >
+                                <FileText className="h-3 w-3 text-muted-foreground" />
+                                {f}
+                                <ExternalLink className="h-3 w-3 text-muted-foreground" />
+                            </a>
+                        ))}
+                    </div>
+
+                    <div className="space-y-3">
+                        <div className="flex items-center justify-between gap-3">
+                            <h2 className="flex items-center gap-2 text-sm font-semibold">
+                                <BookOpen className="h-4 w-4 text-brand" />
+                                Module explorer
+                            </h2>
+                            <div className="relative w-56">
+                                <Search className="absolute left-2.5 top-2 h-3.5 w-3.5 text-muted-foreground" />
+                                <input
+                                    value={search}
+                                    onChange={(e) => setSearch(e.target.value)}
+                                    placeholder="Filter modules or files…"
+                                    className="h-8 w-full rounded-md border border-input bg-background pl-8 pr-2 text-xs focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                                />
+                            </div>
+                        </div>
+
+                        {modules.map((mod) => (
+                            <div key={mod.name} className="rounded-lg border border-border bg-card">
+                                <button
+                                    type="button"
+                                    onClick={() => toggleModule(mod.name)}
+                                    className="flex w-full items-center gap-2 px-4 py-3 text-left hover:bg-muted/40"
+                                >
+                                    {expanded.has(mod.name)
+                                        ? <ChevronDown className="h-4 w-4 shrink-0 text-muted-foreground" />
+                                        : <ChevronRight className="h-4 w-4 shrink-0 text-muted-foreground" />}
+                                    <span className="font-mono text-sm font-medium">{mod.name}</span>
+                                    <span className="text-xs text-muted-foreground">{mod.files.length || '—'} files</span>
+                                    {mod.driftCount > 0 && (
+                                        <span className="ml-auto rounded-full bg-amber-500/10 px-2 py-0.5 text-[11px] font-medium text-amber-700 dark:text-amber-400">
+                                            {mod.driftCount} changed
+                                        </span>
+                                    )}
+                                </button>
+                                {expanded.has(mod.name) && (
+                                    <div className="space-y-3 border-t border-border px-4 py-3">
+                                        {mod.raw && <p className="whitespace-pre-wrap text-xs text-muted-foreground">{mod.raw}</p>}
+                                        {mod.files.map((f) => (
+                                            <div key={f.path} className="space-y-1">
+                                                <a
+                                                    href={`https://github.com/${repo}/blob/${branch}/${f.path}`}
+                                                    target="_blank"
+                                                    rel="noopener noreferrer"
+                                                    className="font-mono text-xs font-medium text-brand hover:underline"
+                                                >
+                                                    {f.path}
+                                                </a>
+                                                <p className="text-xs text-muted-foreground">{f.purpose}</p>
+                                                {f.exports.length > 0 && (
+                                                    <div className="flex flex-wrap gap-1">
+                                                        {f.exports.map((ex) => (
+                                                            <code key={ex} className="rounded bg-muted px-1.5 py-0.5 text-[11px]">{ex}</code>
+                                                        ))}
+                                                    </div>
+                                                )}
+                                                {f.notes && <p className="text-[11px] italic text-muted-foreground/80">{f.notes}</p>}
+                                            </div>
+                                        ))}
+                                    </div>
+                                )}
+                            </div>
+                        ))}
+
+                        {modules.length === 0 && (
+                            <p className="rounded-lg border border-border bg-card p-4 text-center text-xs text-muted-foreground">
+                                No modules match “{search}”.
+                            </p>
+                        )}
+                    </div>
+                </div>
+            )}
+        </div>
+    );
+}

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -61,6 +61,12 @@ const tools = [
         desc: "Scheduled mirror backups that run inside your GitHub.",
         icon: '<path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8"/><path d="M3 3v5h5"/><path d="M12 7v5l4 2"/>',
     },
+    {
+        href: "/tools/knowledge-mapper",
+        name: "Knowledge Mapper",
+        desc: "An agent-ready map of your codebase, tracked for drift.",
+        icon: '<rect x="16" y="16" width="6" height="6" rx="1"/><rect x="2" y="16" width="6" height="6" rx="1"/><rect x="9" y="2" width="6" height="6" rx="1"/><path d="M5 16v-3a1 1 0 0 1 1-1h12a1 1 0 0 1 1 1v3"/><path d="M12 12V8"/>',
+    },
 ];
 ---
 

--- a/src/pages/tools/knowledge-mapper.astro
+++ b/src/pages/tools/knowledge-mapper.astro
@@ -1,0 +1,136 @@
+---
+import BaseLayout from "@/layouts/BaseLayout.astro";
+import "@/styles/global.css";
+import { SiteHeader } from "@/components/SiteHeader";
+import { Footer } from "@/components/Footer";
+import getUser from "@/lib/getUser";
+import { toClientUser } from "@/lib/clientUser";
+import { KnowledgeMapper } from "@/components/tools/KnowledgeMapper";
+
+const user = await getUser(Astro.cookies.get("app_auth_token")?.value);
+
+if (!user) {
+    return Astro.redirect("/?login=1&next=" + encodeURIComponent(Astro.url.pathname));
+}
+---
+
+<BaseLayout title="Knowledge Mapper - Gitset">
+    <Fragment slot="head">
+        <meta charset="utf-8" />
+        <link rel="icon" type="image/png" href="/favicon-96.png" />
+        <meta name="viewport" content="width=device-width" />
+        <meta name="generator" content={Astro.generator} />
+        <meta
+            name="description"
+            content="An always-current, agent-ready map of your codebase — generated from source code with your own AI key, tracked for drift on every commit."
+        />
+        <meta property="og:type" content="website" />
+        <meta property="og:url" content="https://gitset.dev/tools/knowledge-mapper" />
+        <meta property="og:title" content="Knowledge Mapper - Gitset" />
+        <meta
+            property="og:description"
+            content="An always-current, agent-ready map of your codebase — generated from source code with your own AI key, tracked for drift on every commit."
+        />
+        <meta property="og:image" content="https://gitset.dev/gitset-poster.jpg" />
+        <meta property="twitter:card" content="summary_large_image" />
+        <meta property="twitter:url" content="https://gitset.dev/tools/knowledge-mapper" />
+        <meta property="twitter:title" content="Knowledge Mapper - Gitset" />
+        <meta
+            property="twitter:description"
+            content="An always-current, agent-ready map of your codebase — generated from source code with your own AI key, tracked for drift on every commit."
+        />
+        <meta property="twitter:image" content="https://gitset.dev/gitset-poster.jpg" />
+        <script is:inline>
+            (function () {
+                const THEME_STORAGE_KEY = "theme";
+                const stored = localStorage.getItem(THEME_STORAGE_KEY);
+                const prefersDark = window.matchMedia(
+                    "(prefers-color-scheme: dark)",
+                ).matches;
+                const theme =
+                    stored === "light" || stored === "dark"
+                        ? stored
+                        : prefersDark
+                          ? "dark"
+                          : "light";
+                document.documentElement.classList.add(theme);
+            })();
+        </script>
+    </Fragment>
+    <body
+        class="bg-background text-foreground antialiased min-h-screen flex flex-col"
+    >
+        <SiteHeader client:load user={toClientUser(user.user)} />
+        <main class="flex-1 container mx-auto px-4 py-8 max-w-4xl">
+            <div class="mb-8 flex items-center gap-3">
+                <div class="p-2 bg-brand/10 rounded-lg">
+                    <svg
+                        xmlns="http://www.w3.org/2000/svg"
+                        width="24"
+                        height="24"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-width="2"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        class="h-6 w-6 text-brand"
+                    >
+                        <rect x="16" y="16" width="6" height="6" rx="1"></rect>
+                        <rect x="2" y="16" width="6" height="6" rx="1"></rect>
+                        <rect x="9" y="2" width="6" height="6" rx="1"></rect>
+                        <path d="M5 16v-3a1 1 0 0 1 1-1h12a1 1 0 0 1 1 1v3"></path>
+                        <path d="M12 12V8"></path>
+                    </svg>
+                </div>
+                <div>
+                    <h1 class="text-2xl font-bold tracking-tight">
+                        Knowledge Mapper
+                    </h1>
+                    <p class="text-sm text-muted-foreground">
+                        An always-current map of your codebase, built for
+                        developers and AI agents — with drift tracked on every
+                        commit.
+                    </p>
+                </div>
+            </div>
+
+            <div
+                class="mb-8 rounded-lg border border-brand/30 bg-brand/5 p-4 flex gap-3 items-start"
+            >
+                <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    width="24"
+                    height="24"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="2"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    class="h-5 w-5 text-brand shrink-0 mt-0.5"
+                >
+                    <path
+                        d="M20 13c0 5-3.5 7.5-7.66 8.95a1 1 0 0 1-.67-.01C7.5 20.5 4 18 4 13V6a1 1 0 0 1 1-1c2 0 4.5-1.2 6.24-2.72a1.17 1.17 0 0 1 1.52 0C14.51 3.81 17 5 19 5a1 1 0 0 1 1 1z"
+                    ></path>
+                    <path d="m9 12 2 2 4-4"></path>
+                </svg>
+                <div class="text-sm space-y-1">
+                    <p class="font-medium">
+                        Generation runs on your machine — your code and keys
+                        never touch a Gitset server.
+                    </p>
+                    <p class="text-muted-foreground text-xs">
+                        The Gitset CLI analyzes your repository locally with
+                        your own AI key, redacts secrets before any AI call,
+                        and shows you the exact cost before spending a token.
+                        This dashboard only reads what you chose to commit.
+                    </p>
+                </div>
+            </div>
+
+            <KnowledgeMapper client:load user={toClientUser(user.user)} />
+        </main>
+        <Footer client:idle />
+    </body>
+</BaseLayout>


### PR DESCRIPTION
## Summary
- New `/tools/knowledge-mapper` page — the web control plane for Knowledge Mapper, reading everything through the existing GitHub proxy. The web app never touches repository content directly, honoring the locked architecture: generation happens in the CLI (`@gitset-dev/cli` v2.4.0), the dashboard only reads what the user chose to commit.
- **Onboarding state** for repos without a knowledge base: what the tool is, three privacy/cost/incrementality value cards, and guided CLI steps with copyable commands — including the optional `gitset knowledge automate` closer.
- **Dashboard state** for repos with a committed `docs/gitset-knowledge/`: generation stats (age, model, coverage, snapshot), per-module drift computed against the snapshot commit via the GitHub compare API, a searchable module explorer built from the cached structured summaries, and quick links to every generated doc.
- **CI automation card**: detects `.github/workflows/gitset-knowledge.yml`, reports the configured trigger (per-push with its branch, per-release, weekly with the computed next run time, or custom when hand-edited), the last workflow run conclusion linked to Actions, and any open `gitset/knowledge-update` PR awaiting review. Repos without automation get a quiet setup nudge.
- Registered in the home tools grid, header Tools dropdown, and footer Products column.

Ships the web phase of the feature; the CLI + pipeline shipped in `gitset-core-v2` and `@gitset-dev/cli` v2.4.0.

Closes #19

## Test plan
- [x] `astro check`: 0 errors.
- [x] Browser-verified with a mocked-fetch harness using a real generated `.state.json` as fixture: onboarding, fresh, drift, automation off/push/weekly, failed-run and pending-update-PR scenarios all render correctly.
- [x] Drift math verified: unmapped files (prose docs) excluded from changed counts; module chips sorted by drift.