### PR TITLE
docs: reflect that automate now offers to enable the PR-permission setting

### DIFF
--- a/src/pages/docs/index.astro
+++ b/src/pages/docs/index.astro
@@ -78,7 +78,7 @@ const troubleshooting = [
     },
     {
         problem: "gitset knowledge automate ran but no pull request appeared",
-        fix: "Enable \"Allow GitHub Actions to create and approve pull requests\" under the repo's Settings > Actions > General > Workflow permissions. Without it, the update still commits and pushes safely — only opening the review PR fails, and the workflow run shows that failure clearly so it's never silently missed. You can also open the PR yourself from the pushed gitset/knowledge-update branch.",
+        fix: "gitset knowledge automate detects this and offers to enable \"Allow GitHub Actions to create and approve pull requests\" via the GitHub API (confirm-gated, like everything else in the command). If you declined, or it couldn't (no admin access, an org policy locking the setting), enable it under the repo's Settings > Actions > General > Workflow permissions. Without it, the update still commits and pushes safely — only opening the review PR fails, and the workflow run shows that failure clearly so it's never silently missed. You can also open the PR yourself from the pushed gitset/knowledge-update branch.",
     },
     {
         problem: "Generated knowledge-base docs mention technology the project no longer uses",


### PR DESCRIPTION
## Summary
Small follow-up to #41: @gitset-dev/cli 2.4.2 automates the "Allow GitHub Actions to create and approve pull requests" repo setting that the troubleshooting entry described as purely manual (find it, click it yourself). Updates the wording to describe the real, current behavior — detected and offered automatically, confirm-gated, with the same manual fallback if declined or unavailable.

## Test plan
- [x] `astro check`: 0 errors.