### PR TITLE
feat: reflect the two CI sync modes in the dashboard and docs

### DIFF
--- a/src/components/tools/KnowledgeMapper.tsx
+++ b/src/components/tools/KnowledgeMapper.tsx
@@ -42,6 +42,7 @@ interface Drift {
 interface Automation {
     status: 'none' | 'configured';
     mode?: 'push' | 'releases' | 'weekly' | 'custom';
+    sync?: 'commit' | 'pr';
     branch?: string;
     nextRunAt?: string | null;
     lastRun?: { conclusion: string | null; status: string; at: string; url: string } | null;
@@ -158,7 +159,9 @@ export function KnowledgeMapper({ user }: { user: User }) {
             }
             if (!wfRes.ok) return;
             const wfData = await wfRes.json();
-            const trigger = parseWorkflowTrigger(decodeBase64Utf8(wfData.content));
+            const wfYaml = decodeBase64Utf8(wfData.content);
+            const trigger = parseWorkflowTrigger(wfYaml);
+            const sync: Automation['sync'] = wfYaml.includes('gh pr create') ? 'pr' : 'commit';
 
             let lastRun: Automation['lastRun'] = null;
             const runsRes = await ghFetch(`/repos/${repoFullName}/actions/workflows/gitset-knowledge.yml/runs?per_page=1`);
@@ -187,6 +190,7 @@ export function KnowledgeMapper({ user }: { user: User }) {
             setAutomation({
                 status: 'configured',
                 mode: trigger.mode,
+                sync,
                 branch: trigger.branch,
                 nextRunAt: next ? next.toISOString() : null,
                 lastRun,
@@ -467,7 +471,7 @@ export function KnowledgeMapper({ user }: { user: User }) {
                                 <Workflow className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
                                 <div className="text-sm">
                                     <p className="font-medium">CI automation is off</p>
-                                    <p className="text-xs text-muted-foreground">Let CI keep this knowledge base fresh — it opens a review PR only when mapped source actually changed. Choose per-push, per-release or weekly:</p>
+                                    <p className="text-xs text-muted-foreground">Let CI keep this knowledge base fresh — zero setup: by default it commits refreshed docs directly when mapped source actually changed (or opens review PRs if you prefer). Choose per-push, per-release or weekly:</p>
                                 </div>
                             </div>
                             <CopyableCommand command="gitset knowledge automate" />
@@ -487,6 +491,8 @@ export function KnowledgeMapper({ user }: { user: User }) {
                                             ? `Runs weekly — next run ${new Date(automation.nextRunAt).toLocaleString()} (${relativeFuture(new Date(automation.nextRunAt))}).`
                                             : 'Runs on a weekly schedule.')}
                                         {automation.mode === 'custom' && 'Custom trigger — the workflow file was edited manually.'}
+                                        {automation.sync === 'commit' && ' Updates are committed directly to the branch.'}
+                                        {automation.sync === 'pr' && ' Updates arrive as review pull requests.'}
                                     </p>
                                 </div>
                             </div>

--- a/src/pages/docs/index.astro
+++ b/src/pages/docs/index.astro
@@ -78,7 +78,7 @@ const troubleshooting = [
     },
     {
         problem: "gitset knowledge automate ran but no pull request appeared",
-        fix: "gitset knowledge automate detects this and offers to enable \"Allow GitHub Actions to create and approve pull requests\" via the GitHub API (confirm-gated, like everything else in the command). If you declined, or it couldn't (no admin access, an org policy locking the setting), enable it under the repo's Settings > Actions > General > Workflow permissions. Some organizations enforce this off with no override at all — the checkbox greys out even on the org's own settings page. In that case, add a repository secret named GITSET_PR_TOKEN with a personal access token (repo scope); it isn't subject to that org-wide restriction, and the workflow picks it up automatically on the next run, no changes needed. Either way, the update still commits and pushes safely — only opening the review PR fails, and the workflow run shows that failure clearly so it's never silently missed. You can also open the PR yourself from the pushed gitset/knowledge-update branch.",
+        fix: "As of @gitset-dev/cli 2.5.0 the default sync mode commits directly and needs no PR permission at all — re-running gitset knowledge automate regenerates the workflow that way. If you specifically want review PRs (--sync pr), the CLI sets up the required access for you: it first tries enabling \"Allow GitHub Actions to create and approve pull requests\" via the API, and if your organization blocks that (the checkbox greys out even on the org's settings page), it offers to store a token from your existing gh login as the GITSET_PR_TOKEN secret — no settings pages, no manual token creation. Either way, the update itself always commits and pushes safely; only the PR step can fail, and the workflow run shows that clearly so it's never silently missed.",
     },
     {
         problem: "Generated knowledge-base docs mention technology the project no longer uses",
@@ -474,7 +474,7 @@ const troubleshooting = [
                                 </div>
                                 <div class="rounded-lg border border-border p-4">
                                     <p class="font-medium text-sm">Keeping it fresh</p>
-                                    <p class="mt-1 text-xs text-muted-foreground leading-relaxed"><code class="text-xs">gitset knowledge automate</code> writes a CI workflow (per push, per release, or weekly) that runs the incremental update and opens a pull request only when mapped source actually changed — unaffected pushes cost nothing.</p>
+                                    <p class="mt-1 text-xs text-muted-foreground leading-relaxed"><code class="text-xs">gitset knowledge automate</code> writes a CI workflow (per push, per release, or weekly) that runs the incremental update when mapped source actually changed — unaffected pushes cost nothing. By default it commits refreshed docs directly (zero setup, works on every repo and org); prefer reviewing each update as a pull request? <code class="text-xs">--sync pr</code> sets up the required access for you, no settings pages or manual tokens.</p>
                                 </div>
                             </div>
                             <p class="max-w-[65ch] text-muted-foreground leading-relaxed">


### PR DESCRIPTION
## Summary
Companion to @gitset-dev/cli 2.5.0, which makes direct commits the default CI sync mode for Knowledge Mapper and turns review PRs into an opt-in with fully automated setup (no manual tokens, no settings pages).

- The dashboard's automation card now detects which sync mode a repo's workflow uses (inspecting the committed workflow through the existing GitHub proxy — `gh pr create` present → PR mode, otherwise direct-commit) and describes it accurately.
- The "automation off" nudge and the docs page (Keeping-it-fresh card + troubleshooting entry) now describe the zero-setup direct-commit default and the automated `--sync pr` provisioning cascade.

## Test plan
- [x] `astro check`: 0 errors.
- [x] Browser-verified with a mocked harness: a commit-mode workflow renders "Updates are committed directly to the branch", a PR-mode workflow renders "Updates arrive as review pull requests", never both.