### PR TITLE
docs: add Knowledge Mapper to the root README toolkit table

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ your terminal — see [the CLI](#the-cli).
 | **Backup Automator** | Wondering if you'd survive losing GitHub. A scheduled mirror backup that runs inside *your* GitHub. |
 | **Repo Profiler** | Empty description and topics fields. Drafted from your code, applied in one click. |
 | **Gitignore Builder** | Copy-pasting `.gitignore` snippets. Stack-aware, generated in seconds. |
+| **Knowledge Mapper** | Coding agents guessing at your architecture. Builds and maintains an agent-ready map of your codebase, tracked for drift. |
 
 Every generator accepts **your own template** — define your format once and
 every draft follows it — and includes a curated library (Conventional


### PR DESCRIPTION
The repo's root README (the GitHub-rendered landing page) never listed Knowledge Mapper in the toolkit table, even though it has its own tool page and docs section. Adds one row, consistent with the existing entries.

Test plan:
- Rendered the table locally to confirm markdown formatting.