### PR TITLE
docs: update homepage demo to the current recommended model

### DIFF
--- a/src/components/ProviderKeysManager.tsx
+++ b/src/components/ProviderKeysManager.tsx
@@ -210,7 +210,7 @@ export default function ProviderKeysManager({ triggerLabel = 'Manage AI provider
                   </select>
                 </label>
                 {modelChoice === CUSTOM && (
-                  <input value={customModel} onChange={(e) => setCustomModel(e.target.value)} placeholder="exact model id, e.g. claude-sonnet-4-6" className={`${inputCls} font-mono`} />
+                  <input value={customModel} onChange={(e) => setCustomModel(e.target.value)} placeholder="exact model id, e.g. claude-sonnet-5" className={`${inputCls} font-mono`} />
                 )}
 
                 <button type="submit" disabled={busy} className="inline-flex items-center gap-2 rounded-md bg-primary text-primary-foreground px-4 py-2 text-sm font-medium hover:bg-primary/90 disabled:opacity-50">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -245,7 +245,7 @@ const tools = [
                             <div><span class="text-[#6CE0DB]">$</span> gitset config</div>
                             <div class="text-white/50">Pick your AI provider: Anthropic (Claude)</div>
                             <div class="text-white/50">Paste your API key: ••••••••••••••••••••••</div>
-                            <div class="text-white/50">Model (default): claude-sonnet-4-6 (recommended)</div>
+                            <div class="text-white/50">Model (default): claude-sonnet-5 (recommended)</div>
                             <div class="text-[#6CE0DB]">✓ anthropic configured (default)</div>
                             <div class="mt-2"><span class="text-[#6CE0DB]">$</span> gitset commit</div>
                             <div class="text-white/50">✓ 2 files staged · generating with <span class="text-white/70">your key</span> (anthropic)</div>
@@ -403,7 +403,7 @@ const tools = [
                     { t: "cmd", text: "gitset config", d: 200 },
                     { t: "dim", text: "Pick your AI provider: Anthropic (Claude)", d: 350 },
                     { t: "dim", prefix: "Paste your API key: ", text: "••••••••••••••••••••••", d: 300 },
-                    { t: "dim", text: "Model (default): claude-sonnet-4-6 (recommended)", d: 350 },
+                    { t: "dim", text: "Model (default): claude-sonnet-5 (recommended)", d: 350 },
                     { t: "ok", text: "✓ anthropic configured (default)", d: 700 },
                     { t: "cmd", text: "gitset commit", cls: "mt-2", d: 200 },
                     { t: "dim", text: "✓ 2 files staged · generating with your key (anthropic)", d: 400 },


### PR DESCRIPTION
## Summary
- gitset-core-v2's curated default for Anthropic moved from \`claude-sonnet-4-6\` to \`claude-sonnet-5\` (verified against Anthropic's own docs — Sonnet 5 is the current \"best combination of speed and intelligence\" tier, matching what the old default was picked for).
- This repo's homepage \`gitset config\` demo (both the static fallback and the animated terminal) and the provider-key manager's custom-model placeholder still showed the old model name. Updated both to stay accurate.

No behavior change — copy only.

## Test plan
- [x] \`pnpm astro check\` — 0 errors (pre-existing warnings/hints unrelated to this change).