### PR TITLE
fix: parse fetch responses defensively in Release Manager

### DIFF
--- a/src/components/tools/ReleaseCreator.tsx
+++ b/src/components/tools/ReleaseCreator.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { RepositorySelector } from '../RepositorySelector';
 import { ghFetch } from '@/lib/githubProxy';
+import { safeFetchJson } from '@/lib/safeFetchJson';
 import { TemplateEditorModal } from '../TemplateEditorModal';
 import { ReferenceSelector } from '../common/ReferenceSelector';
 import { CommitViewer } from '../common/CommitViewer';
@@ -382,9 +383,9 @@ export function ReleaseCreator({ user, initialRepo = '' }: ReleaseCreatorProps) 
                 })
             });
 
-            const data = await res.json();
+            const data = await safeFetchJson(res);
 
-            if (!res.ok) {
+            if (!res.ok || data.error) {
                 const error = new Error(data.error || "Failed to generate Release Notes");
                 throw error;
             }
@@ -495,7 +496,7 @@ export function ReleaseCreator({ user, initialRepo = '' }: ReleaseCreatorProps) 
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({ action: 'bump', type: f.type, content: f.content, tagName })
                 });
-                const data = await res.json();
+                const data = await safeFetchJson(res);
                 if (res.ok && !data.error && !data.unchanged && data.newContent) {
                     changes.push({ type: f.type, file: f.file, sha: f.sha, oldVersion: data.oldVersion, newVersion: data.newVersion, newContent: data.newContent });
                 }
@@ -603,9 +604,9 @@ export function ReleaseCreator({ user, initialRepo = '' }: ReleaseCreatorProps) 
                 })
             });
 
-            const data = await res.json();
+            const data = await safeFetchJson(res);
 
-            if (!res.ok) {
+            if (!res.ok || data.error) {
                 const error = new Error(data.error || "Failed to refine Release Notes");
                 throw error;
             }

--- a/src/lib/safeFetchJson.ts
+++ b/src/lib/safeFetchJson.ts
@@ -1,0 +1,25 @@
+/**
+ * A backend timeout/outage can mean the browser receives a raw, non-JSON
+ * body straight from the hosting platform (a gateway error page, plain
+ * text) instead of ever reaching this app's own proxy code — which always
+ * returns clean JSON, success or failure. Plain `await res.json()` throws
+ * a raw SyntaxError in that case ("Unexpected token '<'... is not valid
+ * JSON"), which is exactly the kind of message this app promises a
+ * non-technical user they'll never have to read.
+ *
+ * Parses defensively and normalizes to the shape callers already expect:
+ * `{ error: string }` on any failure, so existing `data.error` reads keep
+ * working unchanged.
+ */
+export async function safeFetchJson(res: Response): Promise<any> {
+    const raw = await res.text();
+    try {
+        return JSON.parse(raw);
+    } catch {
+        return {
+            error: res.ok
+                ? "The server sent back something unexpected. Try again in a moment."
+                : `The server didn't respond properly (HTTP ${res.status}). Try again in a moment.`,
+        };
+    }
+}


### PR DESCRIPTION
## Summary
- Fixes a real production report: generating/refining release notes could crash with a raw `Unexpected token 'u', "upstream r"... is not valid JSON` shown directly to the user.
- Root cause: a platform-level gateway timeout can hand the browser a raw non-JSON body before it ever reaches this app's own proxy code (which always returns clean JSON, success or failure). Plain `res.json()` throws a raw `SyntaxError` in that case.
- Adds `src/lib/safeFetchJson.ts`: reads the response as text and parses defensively, normalizing any parse failure to `{ error: "..." }` so existing `data.error` call sites keep working unchanged.
- Applies it to `ReleaseCreator.tsx`'s three fetch call sites that hit this app's own API (`handleGenerate`, `handleRefine`, and the manifest-bump call inside `handleCreateRelease`).
- This is defense-in-depth on top of the backend timeout/retry bound already shipped in `gitset-core-v2` (60s×3 retries → 30s×2 retries), which reduces how often a gateway timeout happens in the first place but doesn't eliminate it as a possibility on the frontend.

## Test plan
- [x] `pnpm astro check` — 0 errors
- [x] Standalone unit check of `safeFetchJson` against a synthetic non-JSON `Response` (mirroring the real gateway-timeout body) confirms it returns a clean `{ error }` instead of throwing
- [x] Confirmed the happy-path (valid JSON body) is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)