### PR TITLE
feat: live free-models banner on the main page

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "gitset-web",
+      "runtimeExecutable": "pnpm",
+      "runtimeArgs": ["dev"],
+      "port": 4321
+    }
+  ]
+}

--- a/src/components/FreeModelsBanner.astro
+++ b/src/components/FreeModelsBanner.astro
@@ -28,6 +28,10 @@ interface Props {
     ctaHref?: string;
 }
 const { ctaHref = '/login' } = Astro.props;
+// "Set one up" has to land on the thing it names. Signed in, that is the
+// providers modal itself; signed out, the same destination carried through
+// the OAuth round-trip rather than dropping the visitor on the dashboard to
+// find it themselves.
 
 function contextLabel(n?: number): string {
     if (!n) return '';
@@ -89,7 +93,7 @@ const refreshedOn = updatedAt ? String(updatedAt).slice(0, 10) : null;
                 type="button"
                 aria-expanded="false"
                 aria-controls="fmb-panel"
-                class="ml-auto flex shrink-0 items-center gap-1 rounded-full border border-border/70 px-2.5 py-1 font-medium text-muted-foreground transition-colors hover:border-brand/50 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand sm:ml-0"
+                class="ml-auto flex shrink-0 items-center gap-1 rounded-full border border-border/70 px-2.5 py-1 font-medium text-muted-foreground transition-colors hover:border-brand/50 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand"
             >
                 <span class="fmb-toggle-label">See all</span>
                 <svg class="fmb-chev h-3 w-3 transition-transform" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m6 9 6 6 6-6"/></svg>
@@ -117,7 +121,7 @@ const refreshedOn = updatedAt ? String(updatedAt).slice(0, 10) : null;
                     ))}
                 </ul>
                 <p class="mt-2 text-[11px] text-muted-foreground">
-                    Checked daily against OpenRouter — each one is asked to write a real commit message, and the ones that can't are dropped.
+                    Availability is verified daily against OpenRouter.
                     {refreshedOn && <span> Last checked {refreshedOn}.</span>}
                 </p>
             </div>
@@ -126,9 +130,25 @@ const refreshedOn = updatedAt ? String(updatedAt).slice(0, 10) : null;
 
     <style>
         .fmb-viewport {
-            /* Fades the track out at both ends rather than cutting it. */
-            -webkit-mask-image: linear-gradient(to right, transparent, #000 24px, #000 calc(100% - 24px), transparent);
-            mask-image: linear-gradient(to right, transparent, #000 24px, #000 calc(100% - 24px), transparent);
+            /* Fades the track out where it leaves the strip rather than
+               cutting it. Only the right edge by default: at rest the track
+               starts flush at x=0, so a left fade lands on the first chip's
+               first letter ("Ling" reading as "ing"). */
+            -webkit-mask-image: linear-gradient(to right, #000 calc(100% - 24px), transparent);
+            mask-image: linear-gradient(to right, #000 calc(100% - 24px), transparent);
+        }
+        @media (prefers-reduced-motion: no-preference) {
+            /* Once it drifts, chips genuinely exit on the left and need the
+               fade there too. */
+            .fmb-viewport {
+                -webkit-mask-image: linear-gradient(to right, transparent, #000 24px, #000 calc(100% - 24px), transparent);
+                mask-image: linear-gradient(to right, transparent, #000 24px, #000 calc(100% - 24px), transparent);
+            }
+        }
+        /* Expanded, the strip would repeat the first few models directly above
+           the full list. Show one or the other, never both. */
+        .fmb-open .fmb-viewport {
+            display: none;
         }
         .fmb-track {
             /* Two identical copies sit side by side; translating by exactly
@@ -159,10 +179,12 @@ const refreshedOn = updatedAt ? String(updatedAt).slice(0, 10) : null;
             if (!btn || !panel) return;
             const label = btn.querySelector('.fmb-toggle-label');
             const chev = btn.querySelector('.fmb-chev');
+            const banner = document.getElementById('free-models-banner');
             btn.addEventListener('click', () => {
                 const open = btn.getAttribute('aria-expanded') === 'true';
                 btn.setAttribute('aria-expanded', String(!open));
                 panel.hidden = open;
+                if (banner) banner.classList.toggle('fmb-open', !open);
                 if (label) label.textContent = open ? 'See all' : 'Hide';
                 if (chev) chev.style.transform = open ? '' : 'rotate(180deg)';
             });

--- a/src/components/FreeModelsBanner.astro
+++ b/src/components/FreeModelsBanner.astro
@@ -1,0 +1,119 @@
+---
+/**
+ * Live strip under the header: the OpenRouter free models Gitset can run on
+ * right now, with no payment method. See gitset-dev/gitset#56.
+ *
+ * Reads the same public, unauthenticated snapshot the AI Providers modal and
+ * the CLI read, so all three name the same models — a third consumer of one
+ * source of truth, not a fourth list.
+ *
+ * Two rules this file exists to respect:
+ *  - This is the highest-traffic page, so the lookup must never be able to
+ *    break or delay it. getFreeModels() owns that: short timeout, cached
+ *    in-process, and an empty list on any failure — which renders nothing.
+ *  - The hero behind it plays a background video, so only one element ever
+ *    animates (the model name crossfades in a fixed slot) and it stops
+ *    entirely under prefers-reduced-motion.
+ */
+import { getFreeModels } from '@/lib/freeModels';
+interface Props {
+    ctaHref?: string;
+}
+const { ctaHref = '/login' } = Astro.props;
+
+function contextLabel(n?: number): string {
+    if (!n) return '';
+    if (n >= 1_000_000) return `${String(Math.round(n / 100_000) / 10).replace(/\.0$/, '')}M context`;
+    if (n >= 1_000) return `${Math.round(n / 1_000)}K context`;
+    return `${n} context`;
+}
+
+const models = await getFreeModels();
+
+// Lead with the recommended model so the first thing rendered — and the only
+// thing shown without JS or under reduced motion — is the one we'd pick.
+const ordered = [...models].sort((a, b) => Number(!!b.recommended) - Number(!!a.recommended));
+---
+
+{ordered.length > 0 && (
+    <aside
+        id="free-models-banner"
+        class="relative z-20 border-b border-border bg-card/60 backdrop-blur-sm"
+        aria-label="Free AI models available right now"
+    >
+        <div class="container mx-auto flex max-w-6xl flex-wrap items-center justify-center gap-x-3 gap-y-1 px-4 py-2 text-xs sm:justify-between">
+            <p class="flex min-w-0 items-center gap-2 text-muted-foreground">
+                <span class="relative flex h-1.5 w-1.5 shrink-0" aria-hidden="true">
+                    <span class="absolute inline-flex h-full w-full animate-ping rounded-full bg-brand opacity-60 motion-reduce:hidden"></span>
+                    <span class="relative inline-flex h-1.5 w-1.5 rounded-full bg-brand"></span>
+                </span>
+                <span class="font-medium text-foreground">Free AI models — no card required.</span>
+
+                <span class="hidden min-w-0 items-center gap-1.5 sm:inline-flex">
+                    <span aria-hidden="true">Run Gitset on</span>
+                    {/* Rotating slot. The full list is exposed to assistive tech
+                        below instead, so the crossfade never re-announces. */}
+                    <span
+                        id="fmb-rotator"
+                        class="inline-block truncate font-mono text-foreground transition-opacity duration-500 motion-reduce:transition-none"
+                        aria-hidden="true"
+                        data-models={JSON.stringify(
+                            ordered.map((m) => ({ label: m.label, ctx: contextLabel(m.contextTokens) })),
+                        )}
+                    >
+                        {ordered[0].label}
+                        {contextLabel(ordered[0].contextTokens) && (
+                            <span class="text-muted-foreground"> · {contextLabel(ordered[0].contextTokens)}</span>
+                        )}
+                    </span>
+                </span>
+
+                <span class="sr-only">
+                    Currently available: {ordered.map((m) => m.label).join(', ')}. Refreshed daily.
+                </span>
+            </p>
+
+            <span class="flex items-center gap-3">
+                <span class="hidden text-muted-foreground md:inline">
+                    {ordered.length} available · refreshed daily
+                </span>
+                <a
+                    href={ctaHref}
+                    class="font-medium text-brand underline-offset-4 hover:underline"
+                >
+                    Set one up →
+                </a>
+            </span>
+        </div>
+    </aside>
+
+    <script is:inline>
+        (() => {
+            const el = document.getElementById('fmb-rotator');
+            if (!el) return;
+            let list;
+            try {
+                list = JSON.parse(el.dataset.models || '[]');
+            } catch {
+                return;
+            }
+            if (list.length < 2) return;
+            if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
+
+            let i = 0;
+            const render = (m) =>
+                m.ctx
+                    ? `${m.label}<span class="text-muted-foreground"> · ${m.ctx}</span>`
+                    : m.label;
+
+            setInterval(() => {
+                el.style.opacity = '0';
+                setTimeout(() => {
+                    i = (i + 1) % list.length;
+                    el.innerHTML = render(list[i]);
+                    el.style.opacity = '1';
+                }, 500);
+            }, 4000);
+        })();
+    </script>
+)}

--- a/src/components/FreeModelsBanner.astro
+++ b/src/components/FreeModelsBanner.astro
@@ -1,21 +1,29 @@
 ---
 /**
- * Live strip under the header: the OpenRouter free models Gitset can run on
- * right now, with no payment method. See gitset-dev/gitset#56.
+ * Live strip under the header: every OpenRouter model Gitset can run on for
+ * free right now, with no payment method. See gitset-dev/gitset#56.
  *
  * Reads the same public, unauthenticated snapshot the AI Providers modal and
  * the CLI read, so all three name the same models — a third consumer of one
- * source of truth, not a fourth list.
+ * source of truth, not a fourth list. Fitness is decided server-side: the
+ * daily probe asks each model to write a real commit message and drops the
+ * ones that can't, so this renders whatever arrives without second-guessing.
  *
  * Two rules this file exists to respect:
  *  - This is the highest-traffic page, so the lookup must never be able to
  *    break or delay it. getFreeModels() owns that: short timeout, cached
  *    in-process, and an empty list on any failure — which renders nothing.
- *  - The hero behind it plays a background video, so only one element ever
- *    animates (the model name crossfades in a fixed slot) and it stops
- *    entirely under prefers-reduced-motion.
+ *  - The hero behind it plays a background video, so the collapsed strip is
+ *    a single slow drift, no flashing or scaling, paused on hover.
+ *
+ * The row can only ever show the models that fit across it, which on its own
+ * reads as text truncated mid-word — and with motion turned off the drift
+ * can't reveal the rest either. Hence the expander: one click lays every
+ * model out below, and that path works identically whether or not the
+ * visitor allows animation.
  */
 import { getFreeModels } from '@/lib/freeModels';
+
 interface Props {
     ctaHref?: string;
 }
@@ -23,16 +31,16 @@ const { ctaHref = '/login' } = Astro.props;
 
 function contextLabel(n?: number): string {
     if (!n) return '';
-    if (n >= 1_000_000) return `${String(Math.round(n / 100_000) / 10).replace(/\.0$/, '')}M context`;
-    if (n >= 1_000) return `${Math.round(n / 1_000)}K context`;
-    return `${n} context`;
+    if (n >= 1_000_000) return `${String(Math.round(n / 100_000) / 10).replace(/\.0$/, '')}M`;
+    if (n >= 1_000) return `${Math.round(n / 1_000)}K`;
+    return String(n);
 }
 
-const models = await getFreeModels();
-
-// Lead with the recommended model so the first thing rendered — and the only
-// thing shown without JS or under reduced motion — is the one we'd pick.
+const { models, updatedAt } = await getFreeModels();
+// Lead with the recommended model: it is the first thing read, and the only
+// ordering that still means something once the track is looping.
 const ordered = [...models].sort((a, b) => Number(!!b.recommended) - Number(!!a.recommended));
+const refreshedOn = updatedAt ? String(updatedAt).slice(0, 10) : null;
 ---
 
 {ordered.length > 0 && (
@@ -41,79 +49,123 @@ const ordered = [...models].sort((a, b) => Number(!!b.recommended) - Number(!!a.
         class="relative z-20 border-b border-border bg-card/60 backdrop-blur-sm"
         aria-label="Free AI models available right now"
     >
-        <div class="container mx-auto flex max-w-6xl flex-wrap items-center justify-center gap-x-3 gap-y-1 px-4 py-2 text-xs sm:justify-between">
-            <p class="flex min-w-0 items-center gap-2 text-muted-foreground">
-                <span class="relative flex h-1.5 w-1.5 shrink-0" aria-hidden="true">
+        <div class="container mx-auto flex max-w-6xl items-center gap-3 px-4 py-1.5 text-xs sm:gap-4">
+            <p class="flex shrink-0 items-center gap-2">
+                <span class="relative flex h-1.5 w-1.5" aria-hidden="true">
                     <span class="absolute inline-flex h-full w-full animate-ping rounded-full bg-brand opacity-60 motion-reduce:hidden"></span>
                     <span class="relative inline-flex h-1.5 w-1.5 rounded-full bg-brand"></span>
                 </span>
-                <span class="font-medium text-foreground">Free AI models — no card required.</span>
-
-                <span class="hidden min-w-0 items-center gap-1.5 sm:inline-flex">
-                    <span aria-hidden="true">Run Gitset on</span>
-                    {/* Rotating slot. The full list is exposed to assistive tech
-                        below instead, so the crossfade never re-announces. */}
-                    <span
-                        id="fmb-rotator"
-                        class="inline-block truncate font-mono text-foreground transition-opacity duration-500 motion-reduce:transition-none"
-                        aria-hidden="true"
-                        data-models={JSON.stringify(
-                            ordered.map((m) => ({ label: m.label, ctx: contextLabel(m.contextTokens) })),
-                        )}
-                    >
-                        {ordered[0].label}
-                        {contextLabel(ordered[0].contextTokens) && (
-                            <span class="text-muted-foreground"> · {contextLabel(ordered[0].contextTokens)}</span>
-                        )}
-                    </span>
-                </span>
-
-                <span class="sr-only">
-                    Currently available: {ordered.map((m) => m.label).join(', ')}. Refreshed daily.
+                <span class="font-medium text-foreground">
+                    {ordered.length} free models
+                    <span class="hidden text-muted-foreground sm:inline"> — no card required</span>
                 </span>
             </p>
 
-            <span class="flex items-center gap-3">
-                <span class="hidden text-muted-foreground md:inline">
-                    {ordered.length} available · refreshed daily
-                </span>
-                <a
-                    href={ctaHref}
-                    class="font-medium text-brand underline-offset-4 hover:underline"
-                >
-                    Set one up →
-                </a>
-            </span>
+            {/* Drifting track, masked at both edges so models slide out of
+                sight instead of colliding with the label and the buttons. */}
+            <div class="fmb-viewport relative hidden min-w-0 flex-1 overflow-hidden sm:block">
+                <div class="fmb-track flex w-max items-center gap-2">
+                    {/* Each copy is a real element, not a fragment: a fragment
+                        would leave 2N chips as direct children and the
+                        reduced-motion rule could not hide the duplicate. */}
+                    {[0, 1].map((copy) => (
+                        <div class="fmb-copy flex items-center gap-2" aria-hidden={copy === 1 ? 'true' : undefined}>
+                            {ordered.map((m) => (
+                                <span class="inline-flex shrink-0 items-center gap-1.5 rounded-full border border-border/70 bg-background/60 px-2.5 py-0.5">
+                                    <span class="font-medium text-foreground">{m.label}</span>
+                                    {contextLabel(m.contextTokens) && (
+                                        <span class="font-mono text-[10px] text-muted-foreground">{contextLabel(m.contextTokens)}</span>
+                                    )}
+                                    {m.recommended && <span class="font-medium text-brand">rec</span>}
+                                </span>
+                            ))}
+                        </div>
+                    ))}
+                </div>
+            </div>
+
+            <button
+                id="fmb-toggle"
+                type="button"
+                aria-expanded="false"
+                aria-controls="fmb-panel"
+                class="ml-auto flex shrink-0 items-center gap-1 rounded-full border border-border/70 px-2.5 py-1 font-medium text-muted-foreground transition-colors hover:border-brand/50 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand sm:ml-0"
+            >
+                <span class="fmb-toggle-label">See all</span>
+                <svg class="fmb-chev h-3 w-3 transition-transform" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m6 9 6 6 6-6"/></svg>
+            </button>
+
+            <a
+                href={ctaHref}
+                class="shrink-0 rounded-full bg-brand/10 px-3 py-1 font-semibold text-brand ring-1 ring-inset ring-brand/30 transition-colors hover:bg-brand/20 hover:ring-brand/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand"
+            >
+                Set one up
+            </a>
+        </div>
+
+        <div id="fmb-panel" hidden class="border-t border-border/60 bg-background/40">
+            <div class="container mx-auto max-w-6xl px-4 py-3">
+                <ul class="flex flex-wrap gap-2">
+                    {ordered.map((m) => (
+                        <li class="inline-flex items-center gap-1.5 rounded-full border border-border/70 bg-background/60 px-2.5 py-0.5 text-xs">
+                            <span class="font-medium text-foreground">{m.label}</span>
+                            {contextLabel(m.contextTokens) && (
+                                <span class="font-mono text-[10px] text-muted-foreground">{contextLabel(m.contextTokens)}</span>
+                            )}
+                            {m.recommended && <span class="font-medium text-brand">recommended</span>}
+                        </li>
+                    ))}
+                </ul>
+                <p class="mt-2 text-[11px] text-muted-foreground">
+                    Checked daily against OpenRouter — each one is asked to write a real commit message, and the ones that can't are dropped.
+                    {refreshedOn && <span> Last checked {refreshedOn}.</span>}
+                </p>
+            </div>
         </div>
     </aside>
 
+    <style>
+        .fmb-viewport {
+            /* Fades the track out at both ends rather than cutting it. */
+            -webkit-mask-image: linear-gradient(to right, transparent, #000 24px, #000 calc(100% - 24px), transparent);
+            mask-image: linear-gradient(to right, transparent, #000 24px, #000 calc(100% - 24px), transparent);
+        }
+        .fmb-track {
+            /* Two identical copies sit side by side; translating by exactly
+               half the track puts copy 2 where copy 1 began, so the loop has
+               no visible seam. */
+            animation: fmb-drift 40s linear infinite;
+        }
+        .fmb-viewport:hover .fmb-track {
+            animation-play-state: paused;
+        }
+        @keyframes fmb-drift {
+            from { transform: translateX(0); }
+            to { transform: translateX(-50%); }
+        }
+        @media (prefers-reduced-motion: reduce) {
+            /* Stays a single quiet row — the banner must not grow taller just
+               because the drift is off. The expander is how everything gets
+               seen in this mode. */
+            .fmb-track { animation: none; }
+            .fmb-copy:nth-child(2) { display: none; }
+        }
+    </style>
+
     <script is:inline>
         (() => {
-            const el = document.getElementById('fmb-rotator');
-            if (!el) return;
-            let list;
-            try {
-                list = JSON.parse(el.dataset.models || '[]');
-            } catch {
-                return;
-            }
-            if (list.length < 2) return;
-            if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
-
-            let i = 0;
-            const render = (m) =>
-                m.ctx
-                    ? `${m.label}<span class="text-muted-foreground"> · ${m.ctx}</span>`
-                    : m.label;
-
-            setInterval(() => {
-                el.style.opacity = '0';
-                setTimeout(() => {
-                    i = (i + 1) % list.length;
-                    el.innerHTML = render(list[i]);
-                    el.style.opacity = '1';
-                }, 500);
-            }, 4000);
+            const btn = document.getElementById('fmb-toggle');
+            const panel = document.getElementById('fmb-panel');
+            if (!btn || !panel) return;
+            const label = btn.querySelector('.fmb-toggle-label');
+            const chev = btn.querySelector('.fmb-chev');
+            btn.addEventListener('click', () => {
+                const open = btn.getAttribute('aria-expanded') === 'true';
+                btn.setAttribute('aria-expanded', String(!open));
+                panel.hidden = open;
+                if (label) label.textContent = open ? 'See all' : 'Hide';
+                if (chev) chev.style.transform = open ? '' : 'rotate(180deg)';
+            });
         })();
     </script>
 )}

--- a/src/components/ProviderKeysManager.tsx
+++ b/src/components/ProviderKeysManager.tsx
@@ -150,8 +150,12 @@ async function callApi<T>(action: string, payload: Record<string, unknown> = {})
   return data as T;
 }
 
-export default function ProviderKeysManager({ triggerLabel = 'Manage AI providers', triggerClassName, iconOnly = false }: { triggerLabel?: string; triggerClassName?: string; iconOnly?: boolean }) {
-  const [open, setOpen] = useState(false);
+export default function ProviderKeysManager({ triggerLabel = 'Manage AI providers', triggerClassName, iconOnly = false, autoOpen = false }: { triggerLabel?: string; triggerClassName?: string; iconOnly?: boolean; autoOpen?: boolean }) {
+  // Opened for the visitor when they arrived here to do exactly this (a
+  // "Set one up" CTA elsewhere on the site). Only the page that owns the
+  // intent passes this — the header mounts this component too, and every
+  // instance reading the URL itself would stack modals.
+  const [open, setOpen] = useState(autoOpen);
   const [providers, setProviders] = useState<Record<string, ProviderInfo>>({});
   const [keys, setKeys] = useState<StoredKey[]>([]);
   const [loading, setLoading] = useState(true);

--- a/src/lib/freeModels.ts
+++ b/src/lib/freeModels.ts
@@ -9,6 +9,12 @@
  *
  * Failures are cached too, briefly: during an outage the page should stop
  * retrying on every request instead of making each visitor wait.
+ *
+ * Asks for `limit=all` rather than the picker's short list: this displays
+ * every model fit to use that day instead of asking anyone to choose one.
+ * "Fit" is the server's call — the daily probe asks each model to write a
+ * real commit message and drops the ones that can't, so nothing unfit
+ * reaches this list to be filtered again here.
  */
 export interface FreeModel {
     id: string;
@@ -23,30 +29,39 @@ const TTL_OK_MS = 10 * 60_000;
 const TTL_EMPTY_MS = 60_000;
 const TIMEOUT_MS = 2000;
 
-let cache: { at: number; models: FreeModel[] } | null = null;
+export interface FreeModelsSnapshot {
+    models: FreeModel[];
+    /** When the daily refresh last ran, for showing how fresh the list is. */
+    updatedAt: string | null;
+}
 
-export async function getFreeModels(): Promise<FreeModel[]> {
+let cache: { at: number; snapshot: FreeModelsSnapshot } | null = null;
+
+export async function getFreeModels(): Promise<FreeModelsSnapshot> {
     const now = Date.now();
     if (cache) {
-        const ttl = cache.models.length ? TTL_OK_MS : TTL_EMPTY_MS;
-        if (now - cache.at < ttl) return cache.models;
+        const ttl = cache.snapshot.models.length ? TTL_OK_MS : TTL_EMPTY_MS;
+        if (now - cache.at < ttl) return cache.snapshot;
     }
 
     let models: FreeModel[] = [];
+    let updatedAt: string | null = null;
     try {
         const controller = new AbortController();
         const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
-        const res = await fetch(`${process.env.CORE_API_URL}/api/openrouter-free-models`, {
+        const res = await fetch(`${process.env.CORE_API_URL}/api/openrouter-free-models?limit=all`, {
             signal: controller.signal,
         }).finally(() => clearTimeout(timer));
         if (res.ok) {
             const data = await res.json();
             if (Array.isArray(data?.models)) models = data.models;
+            if (typeof data?.updatedAt === 'string') updatedAt = data.updatedAt;
         }
     } catch {
         // Rendering no banner is strictly better than a slow or broken page.
     }
 
-    cache = { at: now, models };
-    return models;
+    const snapshot: FreeModelsSnapshot = { models, updatedAt };
+    cache = { at: now, snapshot };
+    return snapshot;
 }

--- a/src/lib/freeModels.ts
+++ b/src/lib/freeModels.ts
@@ -1,0 +1,52 @@
+/**
+ * Server-side reader for the OpenRouter free-model snapshot that the AI
+ * Providers modal and the CLI also read (gitset-dev/gitset#56).
+ *
+ * Cached in-process because this runs on the landing page, the highest-traffic
+ * page there is, while the underlying data changes once a day. Without a cache
+ * every visitor pays the round-trip, and a core that hangs rather than refuses
+ * would block each render for the full timeout.
+ *
+ * Failures are cached too, briefly: during an outage the page should stop
+ * retrying on every request instead of making each visitor wait.
+ */
+export interface FreeModel {
+    id: string;
+    label: string;
+    contextTokens?: number;
+    maxOutputTokens?: number;
+    goodFor?: string;
+    recommended?: boolean;
+}
+
+const TTL_OK_MS = 10 * 60_000;
+const TTL_EMPTY_MS = 60_000;
+const TIMEOUT_MS = 2000;
+
+let cache: { at: number; models: FreeModel[] } | null = null;
+
+export async function getFreeModels(): Promise<FreeModel[]> {
+    const now = Date.now();
+    if (cache) {
+        const ttl = cache.models.length ? TTL_OK_MS : TTL_EMPTY_MS;
+        if (now - cache.at < ttl) return cache.models;
+    }
+
+    let models: FreeModel[] = [];
+    try {
+        const controller = new AbortController();
+        const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
+        const res = await fetch(`${process.env.CORE_API_URL}/api/openrouter-free-models`, {
+            signal: controller.signal,
+        }).finally(() => clearTimeout(timer));
+        if (res.ok) {
+            const data = await res.json();
+            if (Array.isArray(data?.models)) models = data.models;
+        }
+    } catch {
+        // Rendering no banner is strictly better than a slow or broken page.
+    }
+
+    cache = { at: now, models };
+    return models;
+}

--- a/src/pages/dashboard.astro
+++ b/src/pages/dashboard.astro
@@ -91,6 +91,11 @@ const joinedDate = new Date(
     month: "long",
     day: "numeric",
 });
+
+// A "Set one up" CTA elsewhere on the site sends people here to configure a
+// provider; opening the modal for them is the difference between landing on
+// the action and landing near it.
+const wantsProviderSetup = Astro.url.searchParams.get("setup") === "ai-provider";
 ---
 
 <BaseLayout title="Dashboard - Gitset">
@@ -228,7 +233,7 @@ const joinedDate = new Date(
                             to your browser.
                         </p>
                         <div class="mt-3">
-                            <ProviderKeysManager client:load triggerLabel="Manage AI providers" />
+                            <ProviderKeysManager client:load triggerLabel="Manage AI providers" autoOpen={wantsProviderSetup} />
                         </div>
                     </div>
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -3,6 +3,7 @@ import BaseLayout from "@/layouts/BaseLayout.astro";
 import "../styles/global.css";
 import { SiteHeader } from "../components/SiteHeader";
 import { Footer } from "../components/Footer";
+import FreeModelsBanner from "../components/FreeModelsBanner.astro";
 import getUser from "@/lib/getUser";
 import { toClientUser } from "@/lib/clientUser";
 const user = await getUser(Astro.cookies.get("app_auth_token")?.value);
@@ -150,6 +151,7 @@ const tools = [
     </Fragment>
     <body class="bg-background text-foreground antialiased min-h-screen flex flex-col">
         <SiteHeader client:load showBackButton={false} user={toClientUser(user?.user)} />
+        <FreeModelsBanner ctaHref={loggedIn ? "/dashboard" : "/login"} />
 
         <main class="flex-1">
             {/* ── HERO ─────────────────────────────────────────────── */}

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -151,7 +151,7 @@ const tools = [
     </Fragment>
     <body class="bg-background text-foreground antialiased min-h-screen flex flex-col">
         <SiteHeader client:load showBackButton={false} user={toClientUser(user?.user)} />
-        <FreeModelsBanner ctaHref={loggedIn ? "/dashboard" : "/login"} />
+        <FreeModelsBanner ctaHref={loggedIn ? "/dashboard?setup=ai-provider" : "/login?next=%2Fdashboard%3Fsetup%3Dai-provider"} />
 
         <main class="flex-1">
             {/* ── HERO ─────────────────────────────────────────────── */}

--- a/src/pages/login.astro
+++ b/src/pages/login.astro
@@ -11,6 +11,13 @@ if (user) {
 }
 
 const error = Astro.url.searchParams.get("error");
+
+// Carry an intended destination through the OAuth round-trip (the auth route
+// encodes it in `state`, the callback validates and returns to it), so a CTA
+// like "Set one up" lands on the thing it promised rather than the dashboard.
+const rawNext = Astro.url.searchParams.get("next") || "";
+const next = rawNext.startsWith("/") && !rawNext.startsWith("//") ? rawNext : "";
+const signInHref = next ? `/api/auth/github?next=${encodeURIComponent(next)}` : "/api/auth/github";
 ---
 
 <BaseLayout title="Sign in - Gitset">
@@ -67,7 +74,7 @@ const error = Astro.url.searchParams.get("error");
 
                 <div class="mt-8 space-y-4">
                     <a
-                        href="/api/auth/github"
+                        href={signInHref}
                         class="flex w-full items-center justify-center gap-3 rounded-lg bg-[#24292F] px-4 py-3 text-sm font-semibold text-white shadow-sm transition-all hover:bg-[#24292F]/90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#24292F]"
                     >
                         <svg


### PR DESCRIPTION
Closes #56.

## What

A strip under the site header on the main page showing every OpenRouter model Gitset can run on for free right now, collapsed to a single line with a **See all** expander.

Third consumer of the same public `GET /api/openrouter-free-models` the AI Providers modal and the CLI already read — one source of truth, not a fourth list. Nothing assumes a fixed model name or count; the list turned over completely in three days.

Fitness is decided server-side. The daily probe used to ask each model to reply `"OK"` in 5 tokens, which every model passes — that is how a moderation classifier answering `User Safety: safe` was being offered as a working free model. It now sends a real diff, asks for a commit subject, budgets for reasoning tokens and grades the answer, sampling twice so a model that is only sometimes fit is rejected.

## Review feedback applied

- Shows **all** fit models (`?limit=all`), not the picker's short list of five.
- `Set one up →` became a real pill button; the bare arrow read as unfinished.
- The row can only fit a few models, which read as text truncated mid-word — and with motion disabled the drift can't reveal the rest. **See all** expands every model below, and works identically with or without animation.
- The left edge fade landed on the first chip's first letter (`Ling` → `ing`); it now applies only while the track is drifting, since at rest nothing exits on the left.
- Expanding no longer repeats the first models above the full list — the strip hides while the panel is open.
- Dropped the line describing our internal test to visitors; it now states only that availability is verified daily.

## `Set one up` lands on the action

Signed in it opens the providers modal directly (`?setup=ai-provider`); signed out it carries the same destination through the OAuth round-trip, which the auth route already supported via `next`.

Verified with real requests: the destination survives into GitHub's authorize URL (`state=…:::/dashboard?setup=ai-provider`), and a hostile `//evil.com/x` is discarded by the existing relative-path guard.

Only the dashboard's instance receives `autoOpen` — the header mounts this component twice more, and every instance reading the URL itself would stack modals.

## Never breaking the highest-traffic page

Verified against a running dev server, not reasoned about:

| Scenario | Result |
|---|---|
| Core refuses the connection | Full page in **0.13s**, banner absent |
| Core hangs | Bounded by the 2s timeout, page still 200 with full content |
| Normal | First render 0.7s, subsequent **0.02s** (in-process cache) |

`getFreeModels()` caches in-process: 10 min on success, 60s on failure so an outage doesn't make every visitor pay the timeout.

## Verified

- `pnpm astro check` — 0 errors
- Rendered with real live data; expander, collapsed height, dark/light themes, desktop and mobile
- `prefers-reduced-motion` honoured (the preview browser reports `reduce`; the strip stays a single static row and the expander is how everything gets seen)
- No console errors

**Not verified:** the modal actually opening on arrival, which needs an authenticated session the preview browser doesn't have. The chain up to GitHub is verified; the final hop is not.

Also adds `.claude/launch.json` so the dev server can be started by name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
